### PR TITLE
Add .has() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Also contains client side polling of User Notifications.
 The following verbs (acting on subjects) can be used in the API and are emitted as events
 
 * followed (topic id)
+* prefer (preference id)
 * forlater (article uuid)
 * recommended (article uuid)
 * articleFromFollow (article uuid)
@@ -27,6 +28,11 @@ Add an entry to the user's preferences e.g. `add('followed', 'sections:"World"',
 ### .remove(verb, subject) {
 
 Remove an entry from the user's preferences e.g. `remove('followed', 'sections:"World"')`, `remove('forlater', '51b53a4e-df64-11e4-a6c4-00144feab7de')`
+
+### .has(verb, subject) {
+
+Assert whether a user has an entry for a specfic topic e.g. `has('followed', 'sections:"World"').then(function(hasFollowed){ //use hasFollowed boolean  })`
+
 
 ### .notifications.clear(uuids, force)
 

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -142,12 +142,18 @@ MyFtClient.prototype.remove = function (verb, subject, meta) {
 };
 
 MyFtClient.prototype.has = function (verb, subject) {
-	return this.fetch('GET', verbConfig[verb].category + '/' + this.userId + '/' + verb + '/' + verbConfig[verb].subjectPrefix)
-		.then(function (results) {
-			var has = results.Items.length > 0;
-			this.emit(verb + '.has', has);
-			return has;
-		}.bind(this));
+	var isLoaded = this.loaded[verb] && this.loaded[verb].some(function(topic) {
+		return topic.Self.indexOf(subject) > -1;
+	});
+
+	if(isLoaded) {
+		return Promise.resolve(true);
+	} else {
+		return this.fetch('GET', verbConfig[verb].category + '/' + this.userId + '/' + verb + '/' + verbConfig[verb].subjectPrefix + subject)
+			.then(function (results) {
+				return results.Count > 0;
+			}.bind(this));
+	}
 };
 
 module.exports = MyFtClient;

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -141,4 +141,13 @@ MyFtClient.prototype.remove = function (verb, subject, meta) {
 		}.bind(this));
 };
 
+MyFtClient.prototype.has = function (verb, subject) {
+	return this.fetch('GET', verbConfig[verb].category + '/' + this.userId + '/' + verb + '/' + verbConfig[verb].subjectPrefix)
+		.then(function (results) {
+			var has = results.Items.length > 0;
+			this.emit(verb + '.has', has);
+			return has;
+		}.bind(this));
+};
+
 module.exports = MyFtClient;

--- a/tests/fixtures/nofollow.json
+++ b/tests/fixtures/nofollow.json
@@ -1,0 +1,5 @@
+{
+  "Count": 0,
+  "Items": [],
+  "ScannedCount": 0
+}

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -177,6 +177,18 @@ describe('endpoints', function() {
 		});
 
 		it('can assert if a topic has been followed', function (done) {
+			myFtClient.init({
+				userPrefsGuid: true,
+				follow: true
+			}).then(function (){
+				return myFtClient.has('followed', 'authors:\"Arash%20Massoudi\"');
+			}).then(function(hasFollowed) {
+				expect(hasFollowed).to.be.true;
+				done();
+			});
+		});
+
+		it('can assert if a topic has not been followed', function (done) {
 			fetchStub.returns(mockFetch(fixtures.nofollow));
 			myFtClient.init({
 				userPrefsGuid: true

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -9,6 +9,7 @@ var MyFtClient = require('../src/myft-client');
 var Notifications = require('../src/notifications-client');
 var fixtures = {
 	follow: require('./fixtures/follow.json'),
+	nofollow: require('./fixtures/nofollow.json'),
 	forlater: require('./fixtures/forlater.json')
 };
 
@@ -172,6 +173,18 @@ describe('endpoints', function() {
 					expect(evt.detail.subject).to.equal('topic:UUID WITH SPACES');
 					done();
 				});
+			});
+		});
+
+		it('can assert if a topic has been followed', function (done) {
+			fetchStub.returns(mockFetch(fixtures.nofollow));
+			myFtClient.init({
+				userPrefsGuid: true
+			}).then(function (){
+				return myFtClient.has('followed', 'topic:NOFOLLOW');
+			}).then(function(hasFollowed) {
+				expect(hasFollowed).to.be.false;
+				done();
 			});
 		});
 


### PR DESCRIPTION
Simply adds a `.has()` method to the client, allowing developers to assert wether or not a user has an entry for a specific verb/topic combination. A use-case being we do not want to show follow CTAs when a user has already followed a topic.

/cc @wheresrhys @adgad 