### PR TITLE
Prevent early initialisation

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -35,7 +35,6 @@ var MyFtClient = function (opts) {
 MyFtClient.prototype.init = function (opts) {
 	opts = opts || {};
 	if (!this.initialised) {
-		this.initialised = true;
 
 		// must be created here as its methods are documented in the public api
 		this.notifications = new Notifications(this);
@@ -77,7 +76,11 @@ MyFtClient.prototype.init = function (opts) {
 				this.load('preferred');
 			}
 
+			this.initialised = true;
+
 		}.bind(this));
+	} else {
+		return Promise.resolve();
 	}
 };
 


### PR DESCRIPTION
- We were setting initialised state before async session request had returned, which in certain situations was causing a race condition
- Also return a promise from `init()` even if it has been initialised, this allows for multiple init calls

/cc @adgad @wheresrhys 