### PR TITLE
Content length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "0.12.2"
 before_install:
-  - npm install -g origami-build-tools
+  - npm install -g origami-build-tools@^3.0.0
   - origami-build-tools install
 script:
   - make test

--- a/myft-bower.js
+++ b/myft-bower.js
@@ -4,5 +4,5 @@ import MyFtClient from './src/myft-client.js';
 
 export default new MyFtClient({
 	apiReadRoot: 'https://myft-api.ft.com/v1/',
-	apiWriteRoot: 'https://ft-next-myft-api.herokuapp.com/v1/'
+	apiWriteRoot: 'https://ft-next-myft-api.herokuapp.com/v1/',
 });

--- a/myft-bower.js
+++ b/myft-bower.js
@@ -3,6 +3,5 @@
 import MyFtClient from './src/myft-client.js';
 
 export default new MyFtClient({
-	apiReadRoot: 'https://myft-api.ft.com/v1/',
-	apiWriteRoot: 'https://ft-next-myft-api.herokuapp.com/v1/',
+	apiRoot: 'https://ft-next-myft-api.herokuapp.com/v1/',
 });

--- a/myft-npm.js
+++ b/myft-npm.js
@@ -3,8 +3,7 @@
 var MyFTApi = require('./src/myft-api.js');
 
 module.exports = new MyFTApi({
-	apiReadRoot: 'https://myft-api.ft.com/v1/',
-	apiWriteRoot: 'https://ft-next-myft-api.herokuapp.com/v1',
+	apiRoot: 'https://myft-api.ft.com/v1/',
 	headers: {
 		'X-API-KEY': process.env.USER_PREFS_API_KEY || process.env.MYFT_API_KEY
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-myft-client",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Client module to store and display user favourites",
   "main": "myft-npm.js",
   "devDependencies": {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -6,8 +6,7 @@ class MyFtApi {
 		if (!opts.apiRoot) {
 			throw 'Myft API  must be constructed with an api root';
 		}
-		this.apiReadRoot = opts.apiReadRoot;
-		this.apiWriteRoot = opts.apiWrtieRoot;
+		this.apiRoot = opts.apiRoot;
 		this.headers = Object.assign({
 			'Content-Type': 'application/json',
 		}, opts.headers);
@@ -19,16 +18,12 @@ class MyFtApi {
 			headers: this.headers,
 			credentials: 'include'
 		};
-		var url;
 
 		if (method !== 'GET') {
 			options.body = JSON.stringify(data || {});
-			url = this.apiWriteRoot + endpoint;
-		} else {
-			url = this.apiReadRoot + endpoint;
 		}
-
-		return fetch(url, options).then(fetchres.json);
+		return fetch(this.apiRoot + endpoint, options)
+			.then(fetchres.json);
 	}
 
 	getActor (actor, id) {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -1,3 +1,4 @@
+/*global Buffer*/
 'use strict';
 const fetchres = require('fetchres');
 

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -21,6 +21,9 @@ class MyFtApi {
 
 		if (method !== 'GET') {
 			options.body = JSON.stringify(data || {});
+			if(typeof window === 'undefined') {
+				this.headers['Content-Length'] = new Buffer(options.body).length;
+			}
 		}
 		return fetch(this.apiRoot + endpoint, options)
 			.then(fetchres.json);

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -8,8 +8,7 @@ class MyFtClient {
 		if (!opts.apiRoot) {
 			throw 'User prefs must be constructed with an api root';
 		}
-		this.apiReadRoot = opts.apiReadRoot;
-		this.apiWriteRoot = opts.apiWriteRoot;
+		this.apiRoot = opts.apiRoot;
 		this.loaded = {};
 	}
 
@@ -24,8 +23,7 @@ class MyFtClient {
 				this.userId = user.uuid;
 
 				this.api = new MyftApi({
-					apiiReadRoot: this.apiReadRoot,
-					apiWriteRoot: this.apiWriteRoot,
+					apiRoot: this.apiRoot,
 					headers: {
 						'X-FT-Session-Token': session.cookie()
 					}

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -55,8 +55,7 @@ describe('Initialising', function() {
 			return Promise.resolve({uuid:'abcd'});
 		});
 		var myFtClient = new MyFtClient({
-			apiReadRoot: 'testRoot/',
-			apiWriteRoot: 'testRoot/'
+			apiRoot: 'testRoot/'
 		});
 		myFtClient.init({
 			follow: false,
@@ -76,8 +75,7 @@ describe('Initialising', function() {
 			return Promise.reject();
 		});
 		var myFtClient = new MyFtClient({
-			apiWriteRoot: 'testRoot/',
-			apiReadRoot: 'testRoot/'
+			apiRoot: 'testRoot/'
 		});
 		myFtClient.init({
 			follow: false,
@@ -101,8 +99,7 @@ describe('url personalising', function () {
 			return Promise.resolve({uuid:'abcd'});
 		});
 		var myFtClient = new MyFtClient({
-			apiReadRoot: 'testRoot/',
-			apiWriteRoot: 'testRoot/'
+			apiRoot: 'testRoot/'
 		});
 
 		Promise.all([
@@ -139,8 +136,7 @@ describe('endpoints', function() {
 			return Promise.resolve({uuid:'abcd'});
 		});
 		myFtClient = new MyFtClient({
-			apiReadRoot: 'testRoot/',
-			apiWriteRoot: 'testRoot/'
+			apiRoot: 'testRoot/'
 		});
 	});
 


### PR DESCRIPTION
/cc @Financial-Times/next-myft 

Node fetch by default sends posts as chucked requests and content-length header gets munged to 0. Varnish sees content-length 0 and ignores body on pass.

This could be worked around by [using VCL pipe](http://tech.vg.no/2014/01/13/varnish-requests-with-no-content-length-header/) - but since Fastly doesn't support pipe, we have to explicitly set the content length header in our request.