### PR TITLE
Fix weirdness with node-fetch/Varnish and content-length

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-myft-client",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Client module to store and display user favourites",
   "main": "myft-npm.js",
   "devDependencies": {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -22,8 +22,12 @@ class MyFtApi {
 
 		if (method !== 'GET') {
 			options.body = JSON.stringify(data || {});
-			if(typeof window === 'undefined') {
-				this.headers['Content-Length'] = new Buffer(options.body).length;
+			if(process) {
+				this.headers['Content-Length'] = Buffer.byteLength(options.body);
+			}
+		} else {
+			if(process) {
+				this.headers['Content-Length'] = '';
 			}
 		}
 		return fetch(this.apiRoot + endpoint, options)


### PR DESCRIPTION
Two issues here:
- Node-fetch was magically adding a `content-length: 16` to the GET requests which was causing the CDN to keep the connection open. Therefore I'm forcing that header to have an empty value
- We are incorrectly calculating the `content-length` header for non GET requests, now using the class static method `Buffer.byteLength` instead.

/cc @adgad @Lrnk @Financial-Times/next-myft 