### PR TITLE
updated url personalisation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "browserify": "^11.0.1",
     "chai": "^1.9.2",
     "debowerify": "^1.3.1",
+	"fetchres": "^1.5.1",
     "gulp": "^3.8.10",
     "isomorphic-fetch": "^2.0.0",
     "karma": "^0.12.24",

--- a/src/lib/is-immutable-url.js
+++ b/src/lib/is-immutable-url.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var isPersonalisedUrl = require('./is-personalised-url');
+
+module.exports = function (url) {
+	return /^\/(__)?myft\/api\//.test(url) ||
+		/^\/(__)?myft\/product-tour/.test(url) ||
+		isPersonalisedUrl(url);
+};

--- a/src/lib/is-personalised-url.js
+++ b/src/lib/is-personalised-url.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function (url) {
+	return /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(url);
+};

--- a/src/lib/personalise-url.js
+++ b/src/lib/personalise-url.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var isImmutableUrl = require('./is-immutable-url');
+
+module.exports = function (url, uuid) {
+	if (isImmutableUrl(url)) {
+		return url;
+	}
+
+	if(!uuid || !uuid.length) {
+		throw new Error('invalid user uuid: ' + uuid);
+	}
+
+	return url.replace(/myft(?:\/([a-zA-z\-]*))?(\/.[^$\/])?\/?/, function ($0, $1, $2) {
+		return 'myft/' + ($1 ? $1 + '/' : '') + uuid + ($2 || '');
+	});
+};

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -2,6 +2,11 @@
 'use strict';
 const fetchres = require('fetchres');
 
+const lib = {
+	personaliseUrl: require('./lib/personalise-url')
+};
+
+
 class MyFtApi {
 	constructor (opts) {
 		if (!opts.apiRoot) {
@@ -56,6 +61,10 @@ class MyFtApi {
 
 	removeRelationship (actor, id, relationship, subject) {
 		return this.fetchJson('DELETE', `${actor}/${id}/${relationship}/${subject}`);
+	}
+
+	static personaliseUrl(url, uuid) {
+		return lib.personaliseUrl(url, uuid);
 	}
 }
 

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -3,7 +3,9 @@
 const fetchres = require('fetchres');
 
 const lib = {
-	personaliseUrl: require('./lib/personalise-url')
+	personaliseUrl: require('./lib/personalise-url'),
+	isPersonalisedUrl: require('./lib/is-personalised-url'),
+	isImmutableUrl: require('./lib/is-immutable-url')
 };
 
 
@@ -63,8 +65,16 @@ class MyFtApi {
 		return this.fetchJson('DELETE', `${actor}/${id}/${relationship}/${subject}`);
 	}
 
-	static personaliseUrl(url, uuid) {
+	personaliseUrl(url, uuid) {
 		return lib.personaliseUrl(url, uuid);
+	}
+
+	isPersonalisedUrl(url) {
+		return lib.isPersonalisedUrl(url);
+	}
+
+	isImmutableUrl(url) {
+		return lib.isImmutableUrl(url);
 	}
 }
 

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -12,6 +12,16 @@ class MyFtClient {
 		this.loaded = {};
 	}
 
+	static isPersonalisedUrl(url) {
+		return /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(url);
+	}
+
+	static isImmutableUrl(url) {
+		return /^\/(__)?myft\/api\//.test(url) ||
+			/^\/(__)?myft\/product-tour/.test(url) ||
+			MyFtClient.isPersonalisedUrl(url);
+	}
+
 	init (opts) {
 
 		if (this.initialised) {
@@ -96,12 +106,11 @@ class MyFtClient {
 	personaliseUrl (url) {
 		return session.uuid()
 			.then(({uuid}) => {
-				if (/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(url)) {
+				if (MyFtClient.isImmutableUrl(url)) {
 					return url;
 				}
-
-				return url.replace(/myft(\/(?:my-news|saved-articles|my-topics|portfolio|average-push-frequency))?\/?/, function ($0, $1) {
-					return `myft${$1 || ''}/${uuid}`;
+				return url.replace(/myft(?:\/([a-zA-z\-]*))?(\/.[^$\/])?\/?/, function ($0, $1, $2) {
+					return 'myft/' + ($1 ? $1 + '/' : '') + uuid + ($2 || '');
 				});
 			});
 	}

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -3,6 +3,10 @@
 const MyftApi = require('./myft-api');
 const session = require('next-session-client');
 
+const lib = {
+	personaliseUrl: require('./lib/personalise-url')
+};
+
 class MyFtClient {
 	constructor (opts) {
 		if (!opts.apiRoot) {
@@ -10,16 +14,6 @@ class MyFtClient {
 		}
 		this.apiRoot = opts.apiRoot;
 		this.loaded = {};
-	}
-
-	static isPersonalisedUrl(url) {
-		return /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(url);
-	}
-
-	static isImmutableUrl(url) {
-		return /^\/(__)?myft\/api\//.test(url) ||
-			/^\/(__)?myft\/product-tour/.test(url) ||
-			MyFtClient.isPersonalisedUrl(url);
 	}
 
 	init (opts) {
@@ -106,12 +100,7 @@ class MyFtClient {
 	personaliseUrl (url) {
 		return session.uuid()
 			.then(({uuid}) => {
-				if (MyFtClient.isImmutableUrl(url)) {
-					return url;
-				}
-				return url.replace(/myft(?:\/([a-zA-z\-]*))?(\/.[^$\/])?\/?/, function ($0, $1, $2) {
-					return 'myft/' + ($1 ? $1 + '/' : '') + uuid + ($2 || '');
-				});
+				return lib.personaliseUrl(url, uuid);
 			});
 	}
 }

--- a/tests/lib/is-immutable-url.spec.js
+++ b/tests/lib/is-immutable-url.spec.js
@@ -1,0 +1,20 @@
+/*global describe, it, expect, beforeEach, afterEach*/
+/*jshint expr:true*/
+'use strict';
+
+var isImmutableUrl = require('../../src/lib/is-immutable-url');
+
+
+describe('identifying immutable URLs', function () {
+	it('should identify between immutable urls and mutable urls', function () {
+
+		expect(isImmutableUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(isImmutableUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(isImmutableUrl('/myft/product-tour')).to.be.true;
+
+		expect(isImmutableUrl('/myft/my-news/')).to.be.false;
+		expect(isImmutableUrl('/myft/portfolio/')).to.be.false;
+		// ...
+
+	})
+});

--- a/tests/lib/is-personalised-url.spec.js
+++ b/tests/lib/is-personalised-url.spec.js
@@ -1,0 +1,20 @@
+/*global describe, it, expect, beforeEach, afterEach*/
+/*jshint expr:true*/
+'use strict';
+
+var isPersonalisedUrl = require('../../src/lib/is-personalised-url');
+
+
+describe('identifying personalised URLs', function () {
+	it('should identify between personalised urls and not personalised urls', function () {
+
+		expect(isPersonalisedUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(isPersonalisedUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+
+		expect(isPersonalisedUrl('/myft/product-tour')).to.be.false;
+		expect(isPersonalisedUrl('/myft/my-news/')).to.be.false;
+		expect(isPersonalisedUrl('/myft/portfolio/')).to.be.false;
+		// ...
+
+	})
+});

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -1,0 +1,46 @@
+/*global describe, it, expect, beforeEach, afterEach*/
+/*jshint expr:true*/
+'use strict';
+
+var personaliseUrl = require('../../src/lib/personalise-url');
+
+describe('url personalising', function () {
+	it('should be possible to personalise a url', function () {
+
+		var testUuid = 'abcd';
+
+		Promise.all([
+			personaliseUrl('/myft', testUuid),
+			personaliseUrl('/myft/', testUuid),
+			personaliseUrl('/myft/my-news', testUuid),
+			personaliseUrl('/myft/my-news/', testUuid),
+			personaliseUrl('/myft/my-news?query=string', testUuid),
+			personaliseUrl('/myft/preferences', testUuid),
+			personaliseUrl('/myft/portfolio', testUuid),
+			personaliseUrl('/myft/portfolio/', testUuid),
+
+			// immutable URLs
+			personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7', testUuid),
+			personaliseUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7', testUuid),
+			personaliseUrl('/myft/product-tour', testUuid),
+			personaliseUrl('/myft/api/skdjfhksjd', testUuid)
+
+		]).then(function (results) {
+			expect(results.shift()).to.equal('/myft/abcd');
+			expect(results.shift()).to.equal('/myft/abcd');
+			expect(results.shift()).to.equal('/myft/my-news/abcd');
+			expect(results.shift()).to.equal('/myft/my-news/abcd');
+			expect(results.shift()).to.equal('/myft/my-news/abcd?query=string');
+			expect(results.shift()).to.equal('/myft/preferences/abcd');
+			expect(results.shift()).to.equal('/myft/portfolio/abcd');
+			expect(results.shift()).to.equal('/myft/portfolio/abcd');
+
+			// immutable URLs
+			expect(results.shift()).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
+			expect(results.shift()).to.equal('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7');
+			expect(results.shift()).to.equal('/myft/product-tour');
+			expect(results.shift()).to.equal('/myft/api/skdjfhksjd');
+		});
+
+	});
+});

--- a/tests/myft-api.spec.js
+++ b/tests/myft-api.spec.js
@@ -1,0 +1,15 @@
+/*global describe, it, expect, beforeEach, afterEach*/
+/*jshint expr:true*/
+'use strict';
+
+var MyFtApi = require('../src/myft-api');
+
+describe('url personalising', function () {
+	it('should be possible to personalise a url', function () {
+
+		var testUuid = 'abcd';
+
+		expect(MyFtApi.personaliseUrl('/myft', testUuid)).to.equal('/myft/abcd');
+		expect(MyFtApi.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7', testUuid)).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
+	});
+});

--- a/tests/myft-api.spec.js
+++ b/tests/myft-api.spec.js
@@ -1,15 +1,36 @@
 /*global describe, it, expect, beforeEach, afterEach*/
 /*jshint expr:true*/
 'use strict';
+const MyFtApi = require('../src/myft-api');
 
-var MyFtApi = require('../src/myft-api');
+const myFtApi = new MyFtApi({
+	apiRoot: 'https://test-api-route.com',
+	headers: {
+		'X-API-KEY': 'adasd'
+	}
+});
 
 describe('url personalising', function () {
 	it('should be possible to personalise a url', function () {
 
-		var testUuid = 'abcd';
+		const testUuid = 'abcd';
 
-		expect(MyFtApi.personaliseUrl('/myft', testUuid)).to.equal('/myft/abcd');
-		expect(MyFtApi.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7', testUuid)).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
+		expect(myFtApi.personaliseUrl('/myft', testUuid)).to.equal('/myft/abcd');
+		expect(myFtApi.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7', testUuid)).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
 	});
+});
+
+
+describe('identifying personalised URLs', function () {
+	it('should identify between personalised urls and not personalised urls', function () {
+		expect(myFtApi.isPersonalisedUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(myFtApi.isPersonalisedUrl('/myft/my-news/')).to.be.false;
+	})
+});
+
+describe('identifying immutable URLs', function () {
+	it('should identify between immutable urls and mutable urls', function () {
+		expect(myFtApi.isImmutableUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(myFtApi.isImmutableUrl('/myft/my-news/')).to.be.false;
+	})
 });

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -104,35 +104,15 @@ describe('url personalising', function () {
 
 		Promise.all([
 			myFtClient.personaliseUrl('/myft'),
-			myFtClient.personaliseUrl('/myft/'),
-			myFtClient.personaliseUrl('/myft/my-news'),
-			myFtClient.personaliseUrl('/myft/my-news/'),
-			myFtClient.personaliseUrl('/myft/my-news?query=string'),
-			myFtClient.personaliseUrl('/myft/preferences'),
-			myFtClient.personaliseUrl('/myft/portfolio'),
-			myFtClient.personaliseUrl('/myft/portfolio/'),
 
 			// immutable URLs
 			myFtClient.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7'),
-			myFtClient.personaliseUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7'),
-			myFtClient.personaliseUrl('/myft/product-tour'),
-			myFtClient.personaliseUrl('/myft/api/skdjfhksjd')
 
 		]).then(function (results) {
 			expect(results.shift()).to.equal('/myft/abcd');
-			expect(results.shift()).to.equal('/myft/abcd');
-			expect(results.shift()).to.equal('/myft/my-news/abcd');
-			expect(results.shift()).to.equal('/myft/my-news/abcd');
-			expect(results.shift()).to.equal('/myft/my-news/abcd?query=string');
-			expect(results.shift()).to.equal('/myft/preferences/abcd');
-			expect(results.shift()).to.equal('/myft/portfolio/abcd');
-			expect(results.shift()).to.equal('/myft/portfolio/abcd');
 
 			// immutable URLs
 			expect(results.shift()).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
-			expect(results.shift()).to.equal('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7');
-			expect(results.shift()).to.equal('/myft/product-tour');
-			expect(results.shift()).to.equal('/myft/api/skdjfhksjd');
 
 			session.uuid.restore();
 			done();
@@ -144,33 +124,6 @@ describe('url personalising', function () {
 	});
 });
 
-describe('identifying personalised URLs', function () {
-	it('should identify between personalised urls and not personalised urls', function () {
-
-		expect(MyFtClient.isPersonalisedUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
-		expect(MyFtClient.isPersonalisedUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
-
-		expect(MyFtClient.isPersonalisedUrl('/myft/product-tour')).to.be.false;
-		expect(MyFtClient.isPersonalisedUrl('/myft/my-news/')).to.be.false;
-		expect(MyFtClient.isPersonalisedUrl('/myft/portfolio/')).to.be.false;
-		// ...
-
-	})
-});
-
-describe('identifying immutable URLs', function () {
-	it('should identify between immutable urls and mutable urls', function () {
-
-		expect(MyFtClient.isImmutableUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
-		expect(MyFtClient.isImmutableUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
-		expect(MyFtClient.isImmutableUrl('/myft/product-tour')).to.be.true;
-
-		expect(MyFtClient.isImmutableUrl('/myft/my-news/')).to.be.false;
-		expect(MyFtClient.isImmutableUrl('/myft/portfolio/')).to.be.false;
-		// ...
-
-	})
-});
 
 describe('endpoints', function() {
 

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -106,23 +106,64 @@ describe('url personalising', function () {
 			myFtClient.personaliseUrl('/myft'),
 			myFtClient.personaliseUrl('/myft/'),
 			myFtClient.personaliseUrl('/myft/my-news'),
-			myFtClient.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7'),
 			myFtClient.personaliseUrl('/myft/my-news/'),
+			myFtClient.personaliseUrl('/myft/my-news?query=string'),
+			myFtClient.personaliseUrl('/myft/preferences'),
+
+			// immutable URLs
+			myFtClient.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7'),
 			myFtClient.personaliseUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7'),
-			myFtClient.personaliseUrl('/myft/my-news?query=string')
+			myFtClient.personaliseUrl('/myft/product-tour'),
+			myFtClient.personaliseUrl('/myft/api/skdjfhksjd')
+
 		]).then(function (results) {
-			expect(results[0]).to.equal('/myft/abcd');
-			expect(results[1]).to.equal('/myft/abcd');
-			expect(results[2]).to.equal('/myft/my-news/abcd');
-			expect(results[3]).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
-			expect(results[4]).to.equal('/myft/my-news/abcd');
-			expect(results[5]).to.equal('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7');
-			expect(results[6]).to.equal('/myft/my-news/abcd?query=string');
+			expect(results.shift()).to.equal('/myft/abcd');
+			expect(results.shift()).to.equal('/myft/abcd');
+			expect(results.shift()).to.equal('/myft/my-news/abcd');
+			expect(results.shift()).to.equal('/myft/my-news/abcd');
+			expect(results.shift()).to.equal('/myft/my-news/abcd?query=string');
+			expect(results.shift()).to.equal('/myft/preferences/abcd');
+
+			// immutable URLs
+			expect(results.shift()).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
+			expect(results.shift()).to.equal('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7');
+			expect(results.shift()).to.equal('/myft/product-tour');
+			expect(results.shift()).to.equal('/myft/api/skdjfhksjd');
+
 			session.uuid.restore();
 			done();
+		}).catch(function(err) {
+			session.uuid.restore();
+			done(err);
 		});
 
 	});
+});
+
+describe('identifying personalised URLs', function () {
+	it('should identify between personalised urls and not personalised urls', function () {
+
+		expect(MyFtClient.isPersonalisedUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(MyFtClient.isPersonalisedUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+
+		expect(MyFtClient.isPersonalisedUrl('/myft/product-tour')).to.be.false;
+		expect(MyFtClient.isPersonalisedUrl('/myft/my-news/')).to.be.false;
+		// ...
+
+	})
+});
+
+describe('identifying immutable URLs', function () {
+	it('should identify between immutable urls and mutable urls', function () {
+
+		expect(MyFtClient.isImmutableUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(MyFtClient.isImmutableUrl('/myft/my-news/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
+		expect(MyFtClient.isImmutableUrl('/myft/product-tour')).to.be.true;
+
+		expect(MyFtClient.isImmutableUrl('/myft/my-news/')).to.be.false;
+		// ...
+
+	})
 });
 
 describe('endpoints', function() {

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -109,6 +109,8 @@ describe('url personalising', function () {
 			myFtClient.personaliseUrl('/myft/my-news/'),
 			myFtClient.personaliseUrl('/myft/my-news?query=string'),
 			myFtClient.personaliseUrl('/myft/preferences'),
+			myFtClient.personaliseUrl('/myft/portfolio'),
+			myFtClient.personaliseUrl('/myft/portfolio/'),
 
 			// immutable URLs
 			myFtClient.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7'),
@@ -123,6 +125,8 @@ describe('url personalising', function () {
 			expect(results.shift()).to.equal('/myft/my-news/abcd');
 			expect(results.shift()).to.equal('/myft/my-news/abcd?query=string');
 			expect(results.shift()).to.equal('/myft/preferences/abcd');
+			expect(results.shift()).to.equal('/myft/portfolio/abcd');
+			expect(results.shift()).to.equal('/myft/portfolio/abcd');
 
 			// immutable URLs
 			expect(results.shift()).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
@@ -148,6 +152,7 @@ describe('identifying personalised URLs', function () {
 
 		expect(MyFtClient.isPersonalisedUrl('/myft/product-tour')).to.be.false;
 		expect(MyFtClient.isPersonalisedUrl('/myft/my-news/')).to.be.false;
+		expect(MyFtClient.isPersonalisedUrl('/myft/portfolio/')).to.be.false;
 		// ...
 
 	})
@@ -161,6 +166,7 @@ describe('identifying immutable URLs', function () {
 		expect(MyFtClient.isImmutableUrl('/myft/product-tour')).to.be.true;
 
 		expect(MyFtClient.isImmutableUrl('/myft/my-news/')).to.be.false;
+		expect(MyFtClient.isImmutableUrl('/myft/portfolio/')).to.be.false;
 		// ...
 
 	})


### PR DESCRIPTION
Brought this up to date with logic in next-myft-page. As the client is now isomorphic we can call these functions from myft-page and be smug about being super DRY