### PR TITLE
Non-prod api fix

### DIFF
--- a/myft-npm.js
+++ b/myft-npm.js
@@ -3,7 +3,7 @@
 var MyFTApi = require('./src/myft-api.js');
 
 module.exports = new MyFTApi({
-	apiRoot: 'https://myft-api.ft.com/v1/',
+	apiRoot: process.env.TEST_MYFT_API_ROOT || 'https://myft-api.ft.com/v1/',
 	headers: {
 		'X-API-KEY': process.env.USER_PREFS_API_KEY || process.env.MYFT_API_KEY
 	}

--- a/myft-npm.js
+++ b/myft-npm.js
@@ -3,7 +3,7 @@
 var MyFTApi = require('./src/myft-api.js');
 
 module.exports = new MyFTApi({
-	apiRoot: process.env.TEST_MYFT_API_ROOT || 'https://myft-api.ft.com/v1/',
+	apiRoot: process.env.MYFT_API_URL,
 	headers: {
 		'X-API-KEY': process.env.USER_PREFS_API_KEY || process.env.MYFT_API_KEY
 	}

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -22,19 +22,24 @@ class MyFtApi {
 
 	fetchJson (method, endpoint, data) {
 		let queryString = '';
-		var options = {
+		let options = {
 			method,
 			headers: this.headers,
 			credentials: 'include'
 		};
 
+		//On production servers we need to fiddle the content length to prevent errors at CDN caching
+		let needToSetContentLength = process && process.env.NODE_ENV === 'production';
+
 		if (method !== 'GET') {
-			options.body = JSON.stringify(data || {});
-			if(process) {
-				this.headers['Content-Length'] = Buffer.byteLength(options.body);
+			if(data) {
+				options.body = JSON.stringify(data);
+			}
+			if(needToSetContentLength) {
+				this.headers['Content-Length'] = options.body ? Buffer.byteLength(options.body) : '';
 			}
 		} else {
-			if(process) {
+			if(needToSetContentLength) {
 				this.headers['Content-Length'] = '';
 			}
 


### PR DESCRIPTION
- Option to override default API root with environment variable TEST_MYFT_API_ROOT
- Fixes for working with an API which isn't in production

Problems were occurring when pointing at a local version of the myFT API due to the Content-Length header fiddling we do to overcome some problems we were having with the CDN