### PR TITLE
API V2: Enforce use of type property on all methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "sinon": "^1.12.2",
     "textrequireify": "^2.1.1",
     "next-build-tools": "^5.3.0"
+  },
+  "dependencies": {
+    "core-js": "^1.2.5"
   }
 }

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -61,24 +61,24 @@ class MyFtApi {
 		return this.fetchJson('GET', `${actor}/${id}`);
 	}
 
-	getAllRelationship (actor, id, relationship, params) {
-		return this.fetchJson('GET', `${actor}/${id}/${relationship}`,params);
+	getAllRelationship (actor, id, relationship, type, params) {
+		return this.fetchJson('GET', `${actor}/${id}/${relationship}/${type}`,params);
 	}
 
-	getRelationship (actor, id, relationship, subject, params) {
-		return this.fetchJson('GET', `${actor}/${id}/${relationship}/${subject}`, params);
+	getRelationship (actor, id, relationship, type, subject, params) {
+		return this.fetchJson('GET', `${actor}/${id}/${relationship}/${type}/${subject}`, params);
 	}
 
-	addRelationship (actor, id, relationship, data) {
-		return this.fetchJson('POST', `${actor}/${id}/${relationship}`, data);
+	addRelationship (actor, id, relationship, type, data) {
+		return this.fetchJson('POST', `${actor}/${id}/${relationship}/${type}`, data);
 	}
 
-	updateRelationship (actor, id, relationship, subject, data) {
-		return this.fetchJson('PUT', `${actor}/${id}/${relationship}/${subject}`, data);
+	updateRelationship (actor, id, relationship, type, subject, data) {
+		return this.fetchJson('PUT', `${actor}/${id}/${relationship}/${type}/${subject}}`, data);
 	}
 
-	removeRelationship (actor, id, relationship, subject) {
-		return this.fetchJson('DELETE', `${actor}/${id}/${relationship}/${subject}`);
+	removeRelationship (actor, id, relationship, type, subject) {
+		return this.fetchJson('DELETE', `${actor}/${id}/${relationship}/${type}/${subject}`);
 	}
 
 	personaliseUrl(url, uuid) {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -74,7 +74,7 @@ class MyFtApi {
 	}
 
 	updateRelationship (actor, id, relationship, type, subject, data) {
-		return this.fetchJson('PUT', `${actor}/${id}/${relationship}/${type}/${subject}}`, data);
+		return this.fetchJson('PUT', `${actor}/${id}/${relationship}/${type}/${subject}`, data);
 	}
 
 	removeRelationship (actor, id, relationship, type, subject) {

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -53,7 +53,7 @@ class MyFtClient {
 					if(!relationships.has(rel)) { relationships.add(rel); }
 				});
 
-				relationships.forEach(rel => this.load(rel));
+				relationships.forEach(relationship => this.load(relationship));
 
 			});
 	}
@@ -82,10 +82,6 @@ class MyFtClient {
 
 	load (relationship) {
 		const key = `${relationship.relationship}.${relationship.type}`;
-
-		document.body.addEventListener(`myft.${key}.load`, () => {
-			// console.log(`LOADED ${key}`);
-		});
 
 		this.fetchJson('GET', `${this.userId}/${relationship.relationship}/${relationship.type}`)
 			.then(results => {

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -1,4 +1,5 @@
 'use strict';
+require('core-js/fn/set');
 
 const session = require('next-session-client');
 const fetchres = require('fetchres');
@@ -43,14 +44,16 @@ class MyFtClient {
 					'X-FT-Session-Token': session.cookie()
 				};
 
-				let relationships = ['preferred', 'enabled'];
-				additionalRelationships.forEach(extraRelationship => {
-					if(!~relationships.indexOf(extraRelationship)) {
-						relationships.push(extraRelationship);
-					}
+				let relationships = new Set([
+					{relationship: 'preferred', type: 'preference'},
+					{relationship: 'enabled', type: 'endpoint'}
+				]);
+
+				additionalRelationships.forEach(rel => {
+					if(!relationships.has(rel)) { relationships.add(rel); }
 				});
 
-				relationships.forEach(relationship => this.load(relationship));
+				relationships.forEach(rel => this.load(rel));
 
 			});
 	}
@@ -78,58 +81,64 @@ class MyFtClient {
 	}
 
 	load (relationship) {
-		this.fetchJson('GET', `${this.userId}/${relationship}`)
+		const key = `${relationship.relationship}.${relationship.type}`;
+
+		document.body.addEventListener(`myft.${key}.load`, () => {
+			// console.log(`LOADED ${key}`);
+		});
+
+		this.fetchJson('GET', `${this.userId}/${relationship.relationship}/${relationship.type}`)
 			.then(results => {
 				if(!results) {
 					results = emptyResponse;
 				}
-				this.loaded[relationship] = results;
-				this.emit(`${relationship}.load`, results);
+				this.loaded[key] = results;
+				this.emit(`${key}.load`, results);
 			})
 			.catch(err => {
 				if (err.message === 'No user data exists') {
-					this.loaded[relationship] = emptyResponse;
-					this.emit(`${relationship}.load`, this.loaded[relationship]);
+					this.loaded[key] = emptyResponse;
+					this.emit(`${key}.load`, emptyResponse);
 				} else {
 					throw err;
 				}
 			});
 	}
 
-	add (relationship, subject, data) {
-		this.fetchJson('PUT', `${this.userId}/${relationship}/${subject}`, data)
+	add (relationship, type, subject, data) {
+		this.fetchJson('PUT', `${this.userId}/${relationship}/${type}/${subject}`, data)
 			.then(results => {
-				this.emit(`${relationship}.add`, {results, subject, data});
+				this.emit(`${relationship}.${type}.add`, {results, subject, data});
 			});
 	}
 
-	remove (relationship, subject, data) {
-		this.fetchJson('DELETE', `${this.userId}/${relationship}/${subject}`)
+	remove (relationship, type, subject, data) {
+		this.fetchJson('DELETE', `${this.userId}/${relationship}/${type}/${subject}`)
 			.then(()=> {
-				this.emit(`${relationship}.remove`, {subject, data});
+				this.emit(`${relationship}.${type}.remove`, {subject, data});
 			});
 	}
 
-	get (relationship, subject) {
-		return this.getAll(relationship).then(items => {
+	get (relationship, type, subject) {
+		return this.getAll(relationship, type).then(items => {
 			return items.filter(item => this.getUuid(item).indexOf(subject) > -1);
 		});
 	}
 
-	getAll (relationship) {
+	getAll (relationship, type) {
 		return new Promise((resolve) => {
-			if (this.loaded[relationship]) {
-				resolve(this.getItems(relationship));
+			if (this.loaded[`${relationship}.${type}`]) {
+				resolve(this.getItems(relationship, type));
 			} else {
-				document.body.addEventListener(`myft.${relationship}.load`, () => {
-					resolve(this.getItems(relationship));
+				document.body.addEventListener(`myft.${relationship}.${type}.load`, () => {
+					resolve(this.getItems(relationship, type));
 				});
 			}
 		});
 	}
 
-	has (relationship, subject) {
-		return this.get(relationship, subject)
+	has (relationship, type, subject) {
+		return this.get(relationship, type, subject)
 			.then(items => items.length > 0);
 	}
 
@@ -137,8 +146,8 @@ class MyFtClient {
 		return topic.uuid;
 	}
 
-	getItems (relationship) {
-		return this.loaded[relationship].items || [];
+	getItems (relationship, type) {
+		return this.loaded[`${relationship}.${type}`].items || [];
 	}
 
 	personaliseUrl (url) {

--- a/tests/myft-api.spec.js
+++ b/tests/myft-api.spec.js
@@ -43,14 +43,14 @@ describe('identifying personalised URLs', function () {
 	it('should identify between personalised urls and not personalised urls', function () {
 		expect(myFtApi.isPersonalisedUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
 		expect(myFtApi.isPersonalisedUrl('/myft/my-news/')).to.be.false;
-	})
+	});
 });
 
 describe('identifying immutable URLs', function () {
 	it('should identify between immutable urls and mutable urls', function () {
 		expect(myFtApi.isImmutableUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
 		expect(myFtApi.isImmutableUrl('/myft/my-news/')).to.be.false;
-	})
+	});
 });
 
 describe('getting a relationship', function() {
@@ -66,8 +66,8 @@ describe('getting a relationship', function() {
 
 
 	it('should request the API', function(done) {
-		myFtApi.getAllRelationship('user', 'userId', 'followed').then(function() {
-			expect(fetchStub.calledWith('https://test-api-route.com/user/userId/followed')).to.be.true;
+		myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(function() {
+			expect(fetchStub.calledWith('https://test-api-route.com/user/userId/followed/concept')).to.be.true;
 			done();
 		})
 		.catch(done);
@@ -75,13 +75,13 @@ describe('getting a relationship', function() {
 	});
 
 	it('should accept pagination parameters', function(done) {
-		myFtApi.getAllRelationship('user', 'userId', 'followed', {
+		myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept', {
 			page: 2,
 			limit: 10
 		}).then(function() {
-			expect(fetchStub.calledWith('https://test-api-route.com/user/userId/followed?page=2&limit=10')).to.be.true;
+			expect(fetchStub.calledWith('https://test-api-route.com/user/userId/followed/concept?page=2&limit=10')).to.be.true;
 			done();
 		}).catch(done);
 
-	})
-})
+	});
+});


### PR DESCRIPTION
This ports all interface methods to use v2 of the API and therefore enforces a consumer to supply a `type` parameter when accessing a relationship.

E.g. `myFtClient.getAll('followed', 'concept')`

This is a large breaking change so will bump version to 5.0.0

/cc @Financial-Times/next-myft 