### PR TITLE
make work with local API

### DIFF
--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -29,14 +29,21 @@ class MyFtApi {
 		};
 
 		if (method !== 'GET') {
-			options.body = JSON.stringify(data || {});
-			
+
 			// fiddle content length header to appease Fastly
 			if(process && process.env.NODE_ENV === 'production') {
+
+				// fastly requires that empty requests have an empty object for a body and local API requires that
+				// they don't
+				options.body = JSON.stringify(data || {});
+
 				this.headers['Content-Length'] = Buffer.byteLength(options.body);
+
+			} else {
+				options.body = data ? JSON.stringify(data) : null;
 			}
 		} else {
-			// fiddle content length header to appease Fastly
+
 			if(process && process.env.NODE_ENV === 'production') {
 				this.headers['Content-Length'] = '';
 			}

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -30,11 +30,14 @@ class MyFtApi {
 
 		if (method !== 'GET') {
 			options.body = JSON.stringify(data || {});
-			if(process) {
+			
+			// fiddle content length header to appease Fastly
+			if(process && process.env.NODE_ENV === 'production') {
 				this.headers['Content-Length'] = Buffer.byteLength(options.body);
 			}
 		} else {
-			if(process) {
+			// fiddle content length header to appease Fastly
+			if(process && process.env.NODE_ENV === 'production') {
 				this.headers['Content-Length'] = '';
 			}
 

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -33,7 +33,7 @@ class MyFtApi {
 			// fiddle content length header to appease Fastly
 			if(process && process.env.NODE_ENV === 'production') {
 
-				// fastly requires that empty requests have an empty object for a body and local API requires that
+				// Fastly requires that empty requests have an empty object for a body and local API requires that
 				// they don't
 				options.body = JSON.stringify(data || {});
 


### PR DESCRIPTION
@Financial-Times/next-myft Only do the content length fiddle in production (previously I've been fiddling the client in my node_modules when I want to do this). This is fine, right?