### PR TITLE
Add catch for session.uuid

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -55,6 +55,13 @@ class MyFtClient {
 
 				relationships.forEach(relationship => this.load(relationship));
 
+			})
+			.catch(e => {
+				// Keeps console clean for anonymous users
+				if (e.message === 'No session cookie found') {
+					return;
+				}
+				throw e;
 			});
 	}
 


### PR DESCRIPTION
Swallows anonymous-user errors to keep the console clean.
(We’re deeming it an ignorable error when we can’t finding the user due
to their anonymity.)