### PR TITLE
Include actor and actorId in client-side add/remove requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ following relationships are loaded
 
 ## Actors
 
-If `actor` is `'user'` and `actorId` is `null`, then the user's ID is retrieved using [next-session-client](https://github.com/Financial-Times/next-session-client)
+If `actor` is `'user'` and `actorId` is `null`, then it defaults to the user ID retrieved using [next-session-client](https://github.com/Financial-Times/next-session-client)
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ following relationships are loaded
 * preferred
 * enabled
 
+## Actors
+
+If `actor` is `'user'` and `actorId` is `null`, then the user's ID is retrieved using [next-session-client](https://github.com/Financial-Times/next-session-client)
+
 ## API
 
 *Note - there are other undocumented methods but these should not be used externally*
@@ -22,36 +26,68 @@ following relationships are loaded
 ### .init([additionalRelationships])
 
 Initialise the client, loading the relationships requested by default and as specified in the additionalRelationships
-parameter e.g. `init(['saved', 'created'])`
+parameter
 
-### .add(relationship, subject, meta)
+```
+init(['saved', 'created'])
+```
 
-Add an entry to the user's preferences e.g. `add('followed', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=', {})`, `add('saved', '51b53a4e-df64-11e4-a6c4-00144feab7de', {})`
+### .add(actor, actorId, relationship, type, subject, meta)
 
-### .remove(relationship, subject) {
+Add an entry to the actors relationships
+```
+add('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=')
 
-Remove an entry from the user's preferences e.g. `remove('followed', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=')`, `remove('saved', '51b53a4e-df64-11e4-a6c4-00144feab7de')`
+// for the current user
+add('user', null, 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=')
 
-### .get(relationship, subject) {
+add('list', 'contained', 'content', '6a7ad9ba-8d44-11e5-8be4-3506bf20cc2b')
+```
 
-Gets matches when a user has an entry for a specfic subject e.g.
+### .remove(actor, actorId, relationship, type, subject) {
 
-`get('followed', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=').then(function(topic){ //gets the entry for the topic followed  })`
+Remove an entry from the actor's relationships
+```
+remove('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=')
 
-`get('saved', 'd4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(topic){ //gets the entry for the saved article })`
+// for the current user
+remove('user', null, 'saved', 'content', '51b53a4e-df64-11e4-a6c4-00144feab7de')
 
-### .getAll(relationship) {
+remove('list', '8d1fd038-fea1-4848-acb5-87e1f54bfa79', 'contained', 'content', '51b53a4e-df64-11e4-a6c4-00144feab7de')
+```
 
-Gets all nodes for which the user has this relationship e.g. `getAll('created').then(function(createdNodes){ //gets all nodes the user has created })`
+### .get(actor, actorId, relationship, type, subject) {
 
-### .has(relationship, subject) {
+Gets matches when the actor has a relationship with a specfic subject
 
-Assert whether a user has an entry for a specfic topic e.g. `has('saved', 'd4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(hasFollowed){ //use hasFollowed boolean  })`
+```
+get('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=').then(function(topic){ //gets the entry for the topic followed  })
+
+get('user', null, 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=').then(function(topic){ //gets the entry for the topic followed  })
+
+get('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'saved', 'concept', 'd4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(topic){ //gets the entry for the saved article })
+```
+
+### .getAll(actor, actorId, relationship, type) {
+
+Gets all nodes for which the user has this relationship
+```
+getAll('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'created', 'list').then(function(createdLists){ //gets all lists the user has created })
+
+getAll('user', null, 'created', 'list').then(function(createdLists){ //gets all lists the current user has created })
+```
+
+### .has(actor, actorId, relationship, subject) {
+
+Assert whether an actor has a relationship with a specific subject
+```
+has('user', 'null', 'saved', 'content','d4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(hasRelationship){ //use hasRelationship boolean  })
+```
 
 
 ### .notifications.clear(uuids, force)
 
-Remove an array of notifications from the user's myft. If force is falsy a check will be run to make sure the notification exists before sending the rquest to clear it
+Remove an array of notifications from the user's myFT. If force is falsy a check will be run to make sure the notification exists before sending the request to clear it
 
 ### .notifications.markAsSeen(uuids)
 
@@ -64,7 +100,7 @@ These are all fired on `document.body`
 
 ### load
 
-Fired when all data for a given relationship has been loaded e.g. `followed:load`. `event.detail` is an object:
+Fired when all data for a given user relationship has been loaded e.g. `followed:load`. `event.detail` is an object:
 ```
 {
 	Count: // number of items returned,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For some requests, the actor must be specified. Where the actor does not feature
 
 If `actor` is `'user'` and `actorId` is `null`, then it defaults to the user ID retrieved using [next-session-client](https://github.com/Financial-Times/next-session-client)
 
-## API
+## Client-side API
 
 *Note - there are other undocumented methods but these should not be used externally*
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ following relationships are loaded
 
 ## Actors
 
+For some requests, the actor must be specified. Where the actor does not feature in the request parameters, the actor is the current user.
+
 If `actor` is `'user'` and `actorId` is `null`, then it defaults to the user ID retrieved using [next-session-client](https://github.com/Financial-Times/next-session-client)
 
 ## API
@@ -34,14 +36,14 @@ init(['saved', 'created'])
 
 ### .add(actor, actorId, relationship, type, subject, meta)
 
-Add an entry to the actors relationships
+Add an entry to the actor's relationships
 ```
 add('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=')
 
 // for the current user
 add('user', null, 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=')
 
-add('list', 'contained', 'content', '6a7ad9ba-8d44-11e5-8be4-3506bf20cc2b')
+add('list', '8d1fd038-fea1-4848-acb5-87e1f54bfa79', 'contained', 'content', '6a7ad9ba-8d44-11e5-8be4-3506bf20cc2b')
 ```
 
 ### .remove(actor, actorId, relationship, type, subject) {
@@ -56,34 +58,29 @@ remove('user', null, 'saved', 'content', '51b53a4e-df64-11e4-a6c4-00144feab7de')
 remove('list', '8d1fd038-fea1-4848-acb5-87e1f54bfa79', 'contained', 'content', '51b53a4e-df64-11e4-a6c4-00144feab7de')
 ```
 
-### .get(actor, actorId, relationship, type, subject) {
+### .get(relationship, type, subject) {
 
-Gets matches when the actor has a relationship with a specfic subject
+Gets matches when the current user has a relationship with a specific subject
 
 ```
-get('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=').then(function(topic){ //gets the entry for the topic followed  })
+get('followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=').then(function(topic){ //gets the entry for the topic followed  })
 
-get('user', null, 'followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=').then(function(topic){ //gets the entry for the topic followed  })
-
-get('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'saved', 'concept', 'd4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(topic){ //gets the entry for the saved article })
+get('saved', 'concept', 'd4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(topic){ //gets the entry for the saved article })
 ```
 
-### .getAll(actor, actorId, relationship, type) {
+### .getAll(relationship, type) {
 
-Gets all nodes for which the user has this relationship
+Gets all nodes of this type with which the current user has this relationship
 ```
-getAll('user', '378666af-12ce-4d5c-85b4-ba12b419a63c', 'created', 'list').then(function(createdLists){ //gets all lists the user has created })
-
-getAll('user', null, 'created', 'list').then(function(createdLists){ //gets all lists the current user has created })
+getAll('created', 'list').then(function(createdLists){ //gets all lists the user has created })
 ```
 
-### .has(actor, actorId, relationship, subject) {
+### .has(relationship, subject) {
 
-Assert whether an actor has a relationship with a specific subject
+Assert whether the current user has a relationship with a specific subject
 ```
-has('user', 'null', 'saved', 'content','d4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(hasRelationship){ //use hasRelationship boolean  })
+has('saved', 'content','d4feb2e2-628e-11e5-9846-de406ccb37f2').then(function(hasRelationship){ //use hasRelationship boolean  })
 ```
-
 
 ### .notifications.clear(uuids, force)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ to store preferences Details are stored against users' eRightsID.
 
 Also contains client side polling of User Notifications.
 
-## Relationships and subjects
+## Client-side API
+
+*Note - there are other undocumented methods but these should not be used externally*
+
 
 Relationships (between actors and subjects) can be accessed in the API and are emitted as events. By default, the
 following relationships are loaded
@@ -15,15 +18,10 @@ following relationships are loaded
 * preferred
 * enabled
 
-## Actors
 
 For some requests, the actor must be specified. Where the actor does not feature in the request parameters, the actor is the current user.
 
 If `actor` is `'user'` and `actorId` is `null`, then it defaults to the user ID retrieved using [next-session-client](https://github.com/Financial-Times/next-session-client)
-
-## Client-side API
-
-*Note - there are other undocumented methods but these should not be used externally*
 
 ### .init([additionalRelationships])
 

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -108,8 +108,9 @@ class MyFtClient {
 			});
 	}
 
-	add (relationship, type, subject, data) {
-		this.fetchJson('PUT', `${this.userId}/${relationship}/${type}/${subject}`, data)
+	add (actor, actorId, relationship, type, subject, data) {
+		actorId = this.getFallbackActorIdIfNecessary(actor, actorId);
+		this.fetchJson('PUT', `${actor}/${actorId}/${relationship}/${type}/${subject}`, data)
 			.then(results => {
 				this.emit(`${relationship}.${type}.add`, {results, subject, data});
 			});
@@ -158,6 +159,19 @@ class MyFtClient {
 			.then(({uuid}) => {
 				return lib.personaliseUrl(url, uuid);
 			});
+	}
+
+	//private
+	getFallbackActorIdIfNecessary (actor, actorId) {
+		if(!actorId) {
+			if(actor === 'user') {
+				return this.userId;
+			} else {
+				throw new Error('no actorId specified');
+			}
+		} else {
+			return actorId;
+		}
 	}
 }
 

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -110,17 +110,22 @@ class MyFtClient {
 
 	add (actor, actorId, relationship, type, subject, data) {
 		actorId = this.getFallbackActorIdIfNecessary(actor, actorId);
-		this.fetchJson('PUT', `${actor}/${actorId}/${relationship}/${type}/${subject}`, data)
+		return this.fetchJson('PUT', `${actor}/${actorId}/${relationship}/${type}/${subject}`, data)
 			.then(results => {
-				this.emit(`${actor}.${relationship}.${type}.add`, {actorId, results, subject, data});
+				let details = {actorId, results, subject, data};
+				this.emit(`${actor}.${relationship}.${type}.add`, details);
+				return details;
 			});
 	}
 
 	remove (actor, actorId, relationship, type, subject, data) {
 		actorId = this.getFallbackActorIdIfNecessary(actor, actorId);
-		this.fetchJson('DELETE', `${actor}/${actorId}/${relationship}/${type}/${subject}`)
+		return this.fetchJson('DELETE', `${actor}/${actorId}/${relationship}/${type}/${subject}`)
 			.then(()=> {
-				this.emit(`${actor}.${relationship}.${type}.remove`, {actorId, subject, data});
+				let details = {actorId, subject, data};
+				this.emit(`${actor}.${relationship}.${type}.remove`, details);
+				return details;
+
 			});
 	}
 

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -96,12 +96,12 @@ class MyFtClient {
 					results = emptyResponse;
 				}
 				this.loaded[key] = results;
-				this.emit(`${key}.load`, results);
+				this.emit(`user.${key}.load`, results);
 			})
 			.catch(err => {
 				if (err.message === 'No user data exists') {
 					this.loaded[key] = emptyResponse;
-					this.emit(`${key}.load`, emptyResponse);
+					this.emit(`user.${key}.load`, emptyResponse);
 				} else {
 					throw err;
 				}
@@ -135,7 +135,7 @@ class MyFtClient {
 			if (this.loaded[`${relationship}.${type}`]) {
 				resolve(this.getItems(relationship, type));
 			} else {
-				document.body.addEventListener(`myft.${relationship}.${type}.load`, () => {
+				document.body.addEventListener(`myft.user.${relationship}.${type}.load`, () => {
 					resolve(this.getItems(relationship, type));
 				});
 			}

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -112,14 +112,15 @@ class MyFtClient {
 		actorId = this.getFallbackActorIdIfNecessary(actor, actorId);
 		this.fetchJson('PUT', `${actor}/${actorId}/${relationship}/${type}/${subject}`, data)
 			.then(results => {
-				this.emit(`${relationship}.${type}.add`, {results, subject, data});
+				this.emit(`${actor}.${relationship}.${type}.add`, {actorId, results, subject, data});
 			});
 	}
 
-	remove (relationship, type, subject, data) {
-		this.fetchJson('DELETE', `${this.userId}/${relationship}/${type}/${subject}`)
+	remove (actor, actorId, relationship, type, subject, data) {
+		actorId = this.getFallbackActorIdIfNecessary(actor, actorId);
+		this.fetchJson('DELETE', `${actor}/${actorId}/${relationship}/${type}/${subject}`)
 			.then(()=> {
-				this.emit(`${relationship}.${type}.remove`, {subject, data});
+				this.emit(`${actor}.${relationship}.${type}.remove`, {actorId, subject, data});
 			});
 	}
 

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -374,7 +374,7 @@ describe('endpoints', function() {
 		});
 	});
 
-	xdescribe('save for later', function () {
+	describe('save for later', function () {
 		beforeEach(function () {
 			fetchStub.returns(mockFetch(fixtures.saved));
 		});
@@ -420,15 +420,15 @@ describe('endpoints', function() {
 
 		it('can add a save for later with stringified meta', function (done) {
 			myFtClient.init().then(function () {
-				myFtClient.add('saved', 'content', '12345', {
+				myFtClient.add('user', null, 'saved', 'content', '12345', {
 					someKey: "blah"
 				});
 
-				expect(fetchStub.calledWith('testRoot/abcd/saved/content/12345')).to.be.true;
+				expect(fetchStub.args[2][0]).to.equal('testRoot/user/abcd/saved/content/12345');
 				expect(fetchStub.args[2][1].method).to.equal('PUT');
 				expect(fetchStub.args[2][1].headers['Content-Type']).to.equal('application/json');
 				expect(fetchStub.args[2][1]['body']).to.equal('{"someKey":"blah"}');
-				listenOnce('myft.saved.content.add', function(evt) {
+				listenOnce('myft.user.saved.content.add', function(evt) {
 					expect(evt.detail.subject).to.equal('12345');
 					done();
 				});
@@ -439,12 +439,12 @@ describe('endpoints', function() {
 
 		it('can remove a saved', function (done) {
 			myFtClient.init().then(function () {
-				myFtClient.remove('saved', 'content', '12345');
+				myFtClient.remove('user', null, 'saved', 'content', '12345');
 
-				expect(fetchStub.calledWith('testRoot/abcd/saved/content/12345')).to.be.true;
+				expect(fetchStub.args[2][0]).to.equal('testRoot/user/abcd/saved/content/12345');
 				expect(fetchStub.args[2][1].method).to.equal('DELETE');
 				expect(fetchStub.args[2][1].headers['Content-Type']).to.equal('application/json');
-				listenOnce('myft.saved.content.remove', function(evt) {
+				listenOnce('myft.user.saved.content.remove', function(evt) {
 					expect(evt.detail.subject).to.equal('12345');
 					done();
 				});

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -203,7 +203,124 @@ describe('endpoints', function() {
 		session.uuid.restore();
 	});
 
-	describe('followed', function () {
+	describe('user followed', function () {
+
+		beforeEach(function () {
+			fetchStub.returns(mockFetch(fixtures.follow));
+		});
+
+		afterEach(function() {
+			fetchStub.reset();
+		});
+
+		it('loads follow data from server', function(done) {
+			myFtClient.init([
+				{ relationship: 'followed', type: 'concept' }
+			]).then(function () {
+				expect(fetchStub.calledWith('testRoot/abcd/followed/concept')).to.be.true;
+				listenOnce('myft.followed.concept.load', function(evt) {
+					expect(myFtClient.loaded['followed.concept']).to.be.exist;
+					expect(evt.detail.count).to.equal(18);
+					expect(evt.detail.items[0].uuid).to.equal('TnN0ZWluX0dMX0FG-R0w=');
+					done();
+				});
+			})
+				.catch(done);
+		});
+
+		xit('can get a followed concept by the concept\'s ID', function (done) {
+			myFtClient.init([
+				{ relationship: 'followed', type: 'concept' }
+			]).then(function () {
+				return myFtClient.get('followed', 'concept', 'TnN0ZWluX1BOXzIwMDkwNjIzXzI1Mjc=-UE4=').then(stuff => {
+					expect(stuff.length).to.equal(1);
+					expect(stuff[0].name).to.equal('J.K. Rowling');
+					done();
+				});
+			}).catch(done);
+		});
+
+		xit('can get all followed concepts', function (done) {
+			myFtClient.init([
+				{ relationship: 'followed', type: 'concept' }
+			]).then(function () {
+				return myFtClient.getAll('followed', 'concept').then(stuff => {
+					expect(stuff.length).to.equal(18);
+					done();
+				});
+			}).catch(done);
+		});
+
+		it('can add a follow with stringified meta and with the default userId', function (done) {
+			myFtClient.init().then(function () {
+				myFtClient.add('user', null, 'followed', 'concept', 'fds567ksgaj=sagjfhgsy', {
+					someKey: "blah"
+				});
+
+				expect(fetchStub.args[2][0]).to.equal('testRoot/user/abcd/followed/concept/fds567ksgaj=sagjfhgsy');
+				expect(fetchStub.args[2][1].method).to.equal('PUT');
+				expect(fetchStub.args[2][1].headers['Content-Type']).to.equal('application/json');
+				expect(fetchStub.args[2][1]['body']).to.equal('{"someKey":"blah"}');
+				listenOnce('myft.followed.concept.add', function(evt) {
+					expect(evt.detail.subject).to.equal('fds567ksgaj=sagjfhgsy');
+					done();
+				});
+			})
+				.catch(done);
+		});
+
+		it('can add a follow with some other userId', function (done) {
+			myFtClient.init().then(function () {
+				myFtClient.add('user', 'some-other-user-id', 'followed', 'concept', 'fds567ksgaj=sagjfhgsy');
+				expect(fetchStub.args[2][0]).to.equal('testRoot/user/some-other-user-id/followed/concept/fds567ksgaj=sagjfhgsy');
+				done();
+			}).catch(done);
+		});
+
+		xit('can assert if a topic has been followed', function (done) {
+			fetchStub.returns(mockFetch(fixtures.follow));
+			myFtClient.init([
+				{ relationship: 'followed', type: 'concept' }
+			]).then(function () {
+				return myFtClient.has('followed', 'concept', 'TnN0ZWluX0dMX0FG-R0w=');
+			}).then(function(hasFollowed) {
+				expect(hasFollowed).to.be.true;
+				done();
+			})
+				.catch(done);
+		});
+
+		xit('can assert if a topic has not been followed', function (done) {
+			fetchStub.returns(mockFetch(fixtures.nofollow));
+			myFtClient.init([
+				{ relationship: 'followed', type: 'concept' }
+			]).then(function () {
+				return myFtClient.has('followed', 'concept', '');
+			}).then(function(hasFollowed) {
+				expect(hasFollowed).to.be.false;
+				done();
+			})
+				.catch(done);
+
+		});
+
+		xit('can remove a follow', function (done) {
+			myFtClient.init().then(function () {
+				myFtClient.remove('followed', 'concept', 'fds567ksgaj=sagjfhgsy');
+
+				expect(fetchStub.calledWith('testRoot/abcd/followed/concept/fds567ksgaj=sagjfhgsy')).to.be.true;
+				expect(fetchStub.args[2][1].method).to.equal('DELETE');
+				expect(fetchStub.args[2][1].headers['Content-Type']).to.equal('application/json');
+				listenOnce('myft.followed.concept.remove', function (evt) {
+					expect(evt.detail.subject).to.equal('fds567ksgaj=sagjfhgsy');
+					done();
+				});
+			})
+				.catch(done);
+		});
+	});
+
+	xdescribe('followed', function () {
 
 		beforeEach(function () {
 			fetchStub.returns(mockFetch(fixtures.follow));
@@ -312,7 +429,7 @@ describe('endpoints', function() {
 		});
 	});
 
-	describe('save for later', function () {
+	xdescribe('save for later', function () {
 		beforeEach(function () {
 			fetchStub.returns(mockFetch(fixtures.saved));
 		});

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -249,14 +249,13 @@ describe('endpoints', function() {
 				{ relationship: 'followed', type: 'concept' }
 			]).then(function () {
 				expect(fetchStub.calledWith('testRoot/abcd/followed/concept')).to.be.true;
-				listenOnce('myft.followed.concept.load', function(evt) {
+				listenOnce('myft.user.followed.concept.load', function(evt) {
 					expect(myFtClient.loaded['followed.concept']).to.be.exist;
 					expect(evt.detail.count).to.equal(18);
 					expect(evt.detail.items[0].uuid).to.equal('TnN0ZWluX0dMX0FG-R0w=');
 					done();
 				});
-			})
-				.catch(done);
+			}).catch(done);
 		});
 
 		it('can get a followed concept by the concept\'s ID', function (done) {
@@ -385,7 +384,7 @@ describe('endpoints', function() {
 				{ relationship: 'saved', type: 'content' }
 			]).then(function () {
 				expect(fetchStub.calledWith('testRoot/abcd/saved/content')).to.be.true;
-				listenOnce('myft.saved.content.load', function(evt) {
+				listenOnce('myft.user.saved.content.load', function(evt) {
 					expect(myFtClient.loaded['saved.content']).to.be.exist;
 					expect(evt.detail.count).to.equal(3);
 					expect(evt.detail.items[0].uuid = 'd4feb2e2-628e-11e5-9846-de406ccb37f2');


### PR DESCRIPTION
Necessary for client-side manipulation of list relationships

Also changes event names - I can't find anywhere apart from within myft-page and myft-ui that we use these events - can anyone think if I've I missed anything else that would need to be updated?

Also makes add/remove return a promise as well as fire events, just as a convenience

Will definitely be a major release