### PR TITLE
Remove old user-prefs key from server side requests

### DIFF
--- a/myft-npm.js
+++ b/myft-npm.js
@@ -5,6 +5,6 @@ var MyFTApi = require('./src/myft-api.js');
 module.exports = new MyFTApi({
 	apiRoot: process.env.MYFT_API_URL,
 	headers: {
-		'X-API-KEY': process.env.USER_PREFS_API_KEY || process.env.MYFT_API_KEY
+		'X-API-KEY': process.env.MYFT_API_KEY
 	}
 });


### PR DESCRIPTION
So we can isolate traffic between web-app and next

Dependant on this myft-api [PR](https://github.com/Financial-Times/next-myft-api/pull/113)

/cc @adgad 