### PR TITLE
Guard against undefined GUIDs

### DIFF
--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -29,6 +29,10 @@ class MyFtApi {
 			credentials: 'include'
 		};
 
+		if(/undefined/.test(endpoint)) {
+			return Promise.reject('Request should contain undefined.');
+		}
+
 		//Sanitize data
 		data = lib.sanitizeData(data);
 

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -37,6 +37,10 @@ class MyFtClient {
 		return session.uuid()
 			.then(({uuid}) => {
 
+				if(!uuid) {
+					return Promise.reject('Session service returned undefined.');
+				}
+
 				this.userId = uuid;
 
 				this.headers = {

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -85,6 +85,24 @@ describe('Initialising', function() {
 
 	});
 
+	it('exits if undefined guid', function (done) {
+		document.cookie = 'FTSession=bad';
+		sinon.stub(session, 'uuid', function () {
+			return Promise.resolve({uuid: undefined});
+		});
+		let myFtClient = new MyFtClient({
+			apiRoot: 'testRoot/'
+		});
+		myFtClient.init()
+			.catch(function () {
+				expect(myFtClient.userId).not.to.exist;
+				session.uuid.restore();
+				done();
+			});
+
+	});
+
+
 });
 
 describe('Requesting relationships on initialisation', function () {


### PR DESCRIPTION
To prevent this error form reaching the API layer:
https://app.getsentry.com/nextftcom/ft-next-myft-api/issues/107688511/events/4068034066/

This will most likely push the error higher up the chain and manifest itself with `next-frontend` sentry in which we'll hopefully find the culprit pages/ui components.
