### PR TITLE
Personalise url resilience

### DIFF
--- a/src/lib/is-valid-uuid.js
+++ b/src/lib/is-valid-uuid.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = str => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(str);

--- a/src/lib/personalise-url.js
+++ b/src/lib/personalise-url.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var isImmutableUrl = require('./is-immutable-url');
+const isImmutableUrl = require('./is-immutable-url');
+const isValidUuid = require('./is-valid-uuid');
 
 module.exports = function (url, userId) {
 	if (isImmutableUrl(url)) {
 		return url;
 	}
 
-	if(!userId || !userId.length) {
-		throw new Error('invalid user uuid: ' + userId);
+	if(!userId || !userId.length || !isValidUuid(userId)) {
+		throw new Error('Invalid user uuid: ' + userId);
 	}
 
 	return url.replace(/myft(?:\/([a-zA-z\-]*))?(\/.[^$\/])?\/?/, function ($0, $1, $2) {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -6,7 +6,8 @@ const lib = {
 	sanitizeData: require('./lib/sanitize-data'),
 	personaliseUrl: require('./lib/personalise-url'),
 	isPersonalisedUrl: require('./lib/is-personalised-url'),
-	isImmutableUrl: require('./lib/is-immutable-url')
+	isImmutableUrl: require('./lib/is-immutable-url'),
+	isValidUuid: require('./lib/is-valid-uuid')
 };
 
 
@@ -129,6 +130,10 @@ class MyFtApi {
 
 	isImmutableUrl(url) {
 		return lib.isImmutableUrl(url);
+	}
+
+	isValidUuid(str) {
+		return lib.isValidUuid(str);
 	}
 }
 

--- a/tests/lib/is-valid-uuid.spec.js
+++ b/tests/lib/is-valid-uuid.spec.js
@@ -1,0 +1,13 @@
+/*global expect*/
+const isValidUuid = require('../../src/lib/is-valid-uuid');
+
+describe('identifying valid UUIDs', () => {
+	it('should return true for valid UUIDs', () => {
+		expect(isValidUuid('e077a74b-693f-4744-b055-d239f548f356')).to.equal(true);
+	});
+
+	it('should return false for invalid UUIDs', () => {
+		expect(isValidUuid('-')).to.equal(false);
+		expect(isValidUuid()).to.equal(false);
+	});
+});

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -5,82 +5,48 @@
 const personaliseUrl = require('../../src/lib/personalise-url');
 
 describe('url personalising', function () {
-	it('should be possible to personalise a url', function (done) {
+	it('should be possible to personalise a url', function () {
 
 		const userId = 'f0bb6f11-c034-4792-a1c0-3647825363a0';
 		const listId = 'e077a74b-693f-4744-b055-d239f548f356';
 		const articleId = '08be4dcc-885f-11e5-90de-f44762bf9896';
 
-		Promise.all([
-			personaliseUrl(`/myft`, userId),
-			personaliseUrl(`/myft/`, userId),
-			personaliseUrl(`/myft/following`, userId),
-			personaliseUrl(`/myft/following/`, userId),
-			personaliseUrl(`/myft/following.json`, userId),
-			personaliseUrl(`/myft/following?query=string`, userId),
-			personaliseUrl(`/myft/saved-articles`, userId),
-			personaliseUrl(`/myft/saved-articles/`, userId),
-			personaliseUrl(`/myft/explore`, userId),
-			personaliseUrl(`/myft/explore/`, userId),
-			personaliseUrl(`/myft/alerts`, userId),
-			personaliseUrl(`/myft/alerts/`, userId),
+		expect(personaliseUrl(`/myft`, userId)).to.equal(`/myft/${userId}`);
+		expect(personaliseUrl(`/myft/`, userId)).to.equal(`/myft/${userId}`);
+		expect(personaliseUrl(`/myft/following`, userId)).to.equal(`/myft/following/${userId}`);
+		expect(personaliseUrl(`/myft/following/`, userId)).to.equal(`/myft/following/${userId}`);
+		expect(personaliseUrl(`/myft/following.json`, userId)).to.equal(`/myft/following/${userId}.json`);
+		expect(personaliseUrl(`/myft/following?query=string`, userId)).to.equal(`/myft/following/${userId}?query=string`);
+		expect(personaliseUrl(`/myft/saved-articles`, userId)).to.equal(`/myft/saved-articles/${userId}`);
+		expect(personaliseUrl(`/myft/saved-articles/`, userId)).to.equal(`/myft/saved-articles/${userId}`);
+		expect(personaliseUrl(`/myft/explore`, userId)).to.equal(`/myft/explore/${userId}`);
+		expect(personaliseUrl(`/myft/explore/`, userId)).to.equal(`/myft/explore/${userId}`);
+		expect(personaliseUrl(`/myft/alerts`, userId)).to.equal(`/myft/alerts/${userId}`);
+		expect(personaliseUrl(`/myft/alerts/`, userId)).to.equal(`/myft/alerts/${userId}`);
 
-			// immutable URLs
-			personaliseUrl(`/myft/${userId}`, userId),
-			personaliseUrl(`/myft/following/${userId}`, userId),
-			personaliseUrl(`/myft/saved-articles/${userId}`, userId),
-			personaliseUrl(`/myft/explore/${userId}`, userId),
-			personaliseUrl(`/myft/alerts/${userId}`, userId),
-			personaliseUrl(`/myft/product-tour`, userId),
-			personaliseUrl(`/myft/api/skdjfhksjd`, userId),
-			// legacy+immutable URLs
-			personaliseUrl(`/myft/my-news`, userId),
-			personaliseUrl(`/myft/my-topics`, userId),
-			personaliseUrl(`/myft/preferences`, userId),
+		// immutable URLs
+		expect(personaliseUrl(`/myft/${userId}`, userId)).to.equal(`/myft/${userId}`);
+		expect(personaliseUrl(`/myft/following/${userId}`, userId)).to.equal(`/myft/following/${userId}`);
+		expect(personaliseUrl(`/myft/saved-articles/${userId}`, userId)).to.equal(`/myft/saved-articles/${userId}`);
+		expect(personaliseUrl(`/myft/explore/${userId}`, userId)).to.equal(`/myft/explore/${userId}`);
+		expect(personaliseUrl(`/myft/alerts/${userId}`, userId)).to.equal(`/myft/alerts/${userId}`);
+		expect(personaliseUrl(`/myft/product-tour`, userId)).to.equal(`/myft/product-tour`);
+		expect(personaliseUrl(`/myft/api/skdjfhksjd`, userId)).to.equal(`/myft/api/skdjfhksjd`);
 
-			// a url with a non-user uuid in the query string
-			personaliseUrl(`/myft/saved-articles?fragment=true&contentId=${articleId}`, userId),
+		// legacy+immutable URLs
+		expect(personaliseUrl(`/myft/my-news`, userId)).to.equal(`/myft/my-news`);
+		expect(personaliseUrl(`/myft/my-topics`, userId)).to.equal(`/myft/my-topics`);
+		expect(personaliseUrl(`/myft/preferences`, userId)).to.equal(`/myft/preferences`);
 
-			// a public list URL
-			personaliseUrl(`/myft/list/${listId}`, userId),
+		// a url with a non-user uuid in the query string
+		expect(personaliseUrl(`/myft/saved-articles?fragment=true&contentId=${articleId}`, userId)).to.equal(`/myft/saved-articles/${userId}?fragment=true&contentId=${articleId}`);
 
-
-		]).then(function (results) {
-			expect(results.shift()).to.equal(`/myft/${userId}`);
-			expect(results.shift()).to.equal(`/myft/${userId}`);
-			expect(results.shift()).to.equal(`/myft/following/${userId}`);
-			expect(results.shift()).to.equal(`/myft/following/${userId}`);
-			expect(results.shift()).to.equal(`/myft/following/${userId}.json`);
-			expect(results.shift()).to.equal(`/myft/following/${userId}?query=string`);
-			expect(results.shift()).to.equal(`/myft/saved-articles/${userId}`);
-			expect(results.shift()).to.equal(`/myft/saved-articles/${userId}`);
-			expect(results.shift()).to.equal(`/myft/explore/${userId}`);
-			expect(results.shift()).to.equal(`/myft/explore/${userId}`);
-			expect(results.shift()).to.equal(`/myft/alerts/${userId}`);
-			expect(results.shift()).to.equal(`/myft/alerts/${userId}`);
-
-			// immutable URLs
-			expect(results.shift()).to.equal(`/myft/${userId}`);
-			expect(results.shift()).to.equal(`/myft/following/${userId}`);
-			expect(results.shift()).to.equal(`/myft/saved-articles/${userId}`);
-			expect(results.shift()).to.equal(`/myft/explore/${userId}`);
-			expect(results.shift()).to.equal(`/myft/alerts/${userId}`);
-			expect(results.shift()).to.equal(`/myft/product-tour`);
-			expect(results.shift()).to.equal(`/myft/api/skdjfhksjd`);
-			// legacy+immutable URLs
-			expect(results.shift()).to.equal(`/myft/my-news`);
-			expect(results.shift()).to.equal(`/myft/my-topics`);
-			expect(results.shift()).to.equal(`/myft/preferences`);
-
-			// a url with a non-user uuid in the query string
-			expect(results.shift()).to.equal(`/myft/saved-articles/${userId}?fragment=true&contentId=${articleId}`);
-
-			// a list URL (lists are public and contain no user ID)
-			expect(results.shift()).to.equal(`/myft/list/${listId}`);
-
-			done();
-
-	}).catch(done);
+		// a list URL (lists are public and contain no user ID)
+		expect(personaliseUrl(`/myft/list/${listId}`, userId)).to.equal(`/myft/list/${listId}`);
 
 	});
+
+	it('should not be possible to personalise a with an invalid userId', function () {
+
+	})
 });

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -48,5 +48,8 @@ describe('url personalising', function () {
 
 	it('should not be possible to personalise a with an invalid userId', function () {
 
+		const invalidUserId = '-';
+
+		expect(() => personaliseUrl(`/myft`, invalidUserId)).to.throw('Invalid user uuid: ' + invalidUserId);
 	})
 });

--- a/tests/myft-api.spec.js
+++ b/tests/myft-api.spec.js
@@ -31,10 +31,10 @@ describe('url personalising', function () {
 
 	it('should be possible to personalise a url', function () {
 
-		const testUuid = 'abcd';
+		const testUuid = '3f041222-22b9-4098-b4a6-7967e48fe4f7';
 
-		expect(myFtApi.personaliseUrl('/myft', testUuid)).to.equal('/myft/abcd');
-		expect(myFtApi.personaliseUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7', testUuid)).to.equal('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7');
+		expect(myFtApi.personaliseUrl('/myft', testUuid)).to.equal(`/myft/${testUuid}`);
+		expect(myFtApi.personaliseUrl(`/myft/${testUuid}`, testUuid)).to.equal(`/myft/${testUuid}`);
 	});
 });
 


### PR DESCRIPTION
- `isValidUuid` function
- throw error on attempt to personalise URL with invalid uuid