### PR TITLE
Revive 'use strict';

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function (karma) {
 	karma.set({
 		frameworks: [ 'mocha', 'chai', 'browserify' ],

--- a/myft-bower.js
+++ b/myft-bower.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import MyFtClient from './src/myft-client.js';
 
 export default new MyFtClient({

--- a/myft-npm.js
+++ b/myft-npm.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const MyFTApi = require('./src/myft-api.js');
 
 module.exports = new MyFTApi({

--- a/src/lib/is-immutable-url.js
+++ b/src/lib/is-immutable-url.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const isPersonalisedUrl = require('./is-personalised-url');
 const isLegacyUrl = require('./is-legacy-url');
 

--- a/src/lib/is-personalised-url.js
+++ b/src/lib/is-personalised-url.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function (path) {
 	return /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path);
 };

--- a/src/lib/is-valid-uuid.js
+++ b/src/lib/is-valid-uuid.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = str => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(str);

--- a/src/lib/personalise-url.js
+++ b/src/lib/personalise-url.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const isImmutableUrl = require('./is-immutable-url');
 const isValidUuid = require('./is-valid-uuid');
 

--- a/src/lib/sanitize-data.js
+++ b/src/lib/sanitize-data.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const sanitizeBoolean = (str) => {
 	if(str === 'true') return true;
 	if(str === 'false') return false;

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*global Buffer*/
 const fetchres = require('fetchres');
 

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require('core.js/fn/set');
 
 const session = require('next-session-client');

--- a/tests/lib/is-immutable-url.spec.js
+++ b/tests/lib/is-immutable-url.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import chai from 'chai';
 const expect = chai.expect;
 const isImmutableUrl = require('../../src/lib/is-immutable-url');

--- a/tests/lib/is-legacy-url.spec.js
+++ b/tests/lib/is-legacy-url.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import chai from 'chai';
 const expect = chai.expect;
 const isLegacyUrl = require('../../src/lib/is-legacy-url');

--- a/tests/lib/is-personalised-url.spec.js
+++ b/tests/lib/is-personalised-url.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import chai from 'chai';
 const expect = chai.expect;
 const isPersonalisedUrl = require('../../src/lib/is-personalised-url');

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import chai from 'chai';
 const expect = chai.expect;
 const personaliseUrl = require('../../src/lib/personalise-url');

--- a/tests/myft-api.spec.js
+++ b/tests/myft-api.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import chai from 'chai';
 const expect = chai.expect;
 require('isomorphic-fetch');

--- a/tests/myft-client.spec.js
+++ b/tests/myft-client.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import chai from 'chai';
 const expect = chai.expect;
 require('isomorphic-fetch');


### PR DESCRIPTION
As not being babelified in all contexts (e.g. lambda apps)