### PR TITLE
myFT client fetchJson sets content-type

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -94,7 +94,7 @@ class MyFtClient {
 	fetchJson (method, endpoint, data) {
 		let options = {
 			method,
-			headers: this.headers,
+			headers: Object.assign({'content-type': 'application/json; charset=utf-8'}, this.headers),
 			credentials: 'include'
 		};
 


### PR DESCRIPTION
Can anyone think of any reason we wouldn't want `fetchJson` to set the `content-type` header to `application\json`? I'm trying to use the `add` function it from the prefs page and for some reason it sends text content by default