### PR TITLE
Add guard against undefined endpoint in client-side fetch.

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -98,6 +98,10 @@ class MyFtClient {
 			credentials: 'include'
 		};
 
+		if(/undefined/.test(endpoint)) {
+			return Promise.reject('Request should not contain undefined.');
+		}
+
 		if (method !== 'GET') {
 			options.body = JSON.stringify(data || {});
 		}


### PR DESCRIPTION
We have the same guard on the server side but for some reason omitted from the client-side path. This should hopefully allow us to identify which part of the client-side app the errors are being generated. 