### PR TITLE
Fire custom o-errors event for undef tracking

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -99,7 +99,12 @@ class MyFtClient {
 		};
 
 		if(/undefined/.test(endpoint)) {
-			return Promise.reject('Request should not contain undefined.');
+			let msg = 'Request should not contain undefined.';
+			document.body.dispatchEvent(new CustomEvent('oErrors.log', {
+				bubbles: true,
+				detail: { error: new Error(msg) }
+			}));
+			return Promise.reject(msg);
 		}
 
 		if (method !== 'GET') {


### PR DESCRIPTION
Extension from https://github.com/Financial-Times/next-myft-client/pull/103

The rejected promise is most likely being swallowed by the consuming component JS, therefore we need to manually fire an `oErrors.log` event to ensure the error gets logged to Sentry for our diagnosis purposes.