### PR TITLE
Product tour no more (part 1)

### DIFF
--- a/src/lib/is-immutable-url.js
+++ b/src/lib/is-immutable-url.js
@@ -4,7 +4,6 @@ const isPersonalisedUrl = require('./is-personalised-url');
 const isLegacyUrl = require('./is-legacy-url');
 
 module.exports = url => /^\/(__)?myft\/api\//.test(url) ||
-	/^\/(__)?myft\/tour/.test(url) ||
 	/^\/(__)?myft\/list/.test(url) ||
 	isLegacyUrl(url) ||
 	isPersonalisedUrl(url);

--- a/src/lib/is-immutable-url.js
+++ b/src/lib/is-immutable-url.js
@@ -4,7 +4,7 @@ const isPersonalisedUrl = require('./is-personalised-url');
 const isLegacyUrl = require('./is-legacy-url');
 
 module.exports = url => /^\/(__)?myft\/api\//.test(url) ||
-	/^\/(__)?myft\/product-tour/.test(url) ||
+	/^\/(__)?myft\/tour/.test(url) ||
 	/^\/(__)?myft\/list/.test(url) ||
 	isLegacyUrl(url) ||
 	isPersonalisedUrl(url);

--- a/src/lib/is-legacy-url.js
+++ b/src/lib/is-legacy-url.js
@@ -1,1 +1,1 @@
-module.exports = path => /^\/myft\/(my-news|my-topics|preferences|product-tour)/.test(path);
+module.exports = path => /^\/myft\/(my-news|my-topics|preferences|product-tour|clippings)/.test(path);

--- a/src/lib/is-legacy-url.js
+++ b/src/lib/is-legacy-url.js
@@ -1,1 +1,1 @@
-module.exports = path => /^\/myft\/(my-news|my-topics|preferences)/.test(path);
+module.exports = path => /^\/myft\/(my-news|my-topics|preferences|product-tour)/.test(path);

--- a/tests/lib/is-immutable-url.spec.js
+++ b/tests/lib/is-immutable-url.spec.js
@@ -10,7 +10,6 @@ describe('identifying immutable URLs', () => {
 		expect(isImmutableUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
 		expect(isImmutableUrl('/myft/following/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
 		expect(isImmutableUrl('/myft/saved-articles/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
-		expect(isImmutableUrl('/myft/tour')).to.be.true;
 
 		expect(isImmutableUrl('/myft/following/')).to.be.false;
 		expect(isImmutableUrl('/myft/saved-articles/')).to.be.false;

--- a/tests/lib/is-immutable-url.spec.js
+++ b/tests/lib/is-immutable-url.spec.js
@@ -10,7 +10,7 @@ describe('identifying immutable URLs', () => {
 		expect(isImmutableUrl('/myft/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
 		expect(isImmutableUrl('/myft/following/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
 		expect(isImmutableUrl('/myft/saved-articles/3f041222-22b9-4098-b4a6-7967e48fe4f7')).to.be.true;
-		expect(isImmutableUrl('/myft/product-tour')).to.be.true;
+		expect(isImmutableUrl('/myft/tour')).to.be.true;
 
 		expect(isImmutableUrl('/myft/following/')).to.be.false;
 		expect(isImmutableUrl('/myft/saved-articles/')).to.be.false;

--- a/tests/lib/is-immutable-url.spec.js
+++ b/tests/lib/is-immutable-url.spec.js
@@ -24,5 +24,6 @@ describe('identifying immutable URLs', () => {
 		expect(isImmutableUrl('/myft/my-news/')).to.be.true;
 		expect(isImmutableUrl('/myft/my-topics/')).to.be.true;
 		expect(isImmutableUrl('/myft/preferences/')).to.be.true;
+		expect(isImmutableUrl('/myft/product-tour')).to.be.true;
 	})
 });

--- a/tests/lib/is-immutable-url.spec.js
+++ b/tests/lib/is-immutable-url.spec.js
@@ -24,5 +24,6 @@ describe('identifying immutable URLs', () => {
 		expect(isImmutableUrl('/myft/my-topics/')).to.be.true;
 		expect(isImmutableUrl('/myft/preferences/')).to.be.true;
 		expect(isImmutableUrl('/myft/product-tour')).to.be.true;
+		expect(isImmutableUrl('/myft/clippings')).to.be.true;
 	})
 });

--- a/tests/lib/is-personalised-url.spec.js
+++ b/tests/lib/is-personalised-url.spec.js
@@ -12,8 +12,6 @@ describe('identifying personalised URLs', () => {
 
 		expect(isPersonalisedUrl(`/${userId}`)).to.be.true;
 		expect(isPersonalisedUrl(`/following/${userId}`)).to.be.true;
-
-		expect(isPersonalisedUrl('/tour')).to.be.false;
 		expect(isPersonalisedUrl('/following/')).to.be.false;
 
 	});

--- a/tests/lib/is-personalised-url.spec.js
+++ b/tests/lib/is-personalised-url.spec.js
@@ -13,7 +13,7 @@ describe('identifying personalised URLs', () => {
 		expect(isPersonalisedUrl(`/${userId}`)).to.be.true;
 		expect(isPersonalisedUrl(`/following/${userId}`)).to.be.true;
 
-		expect(isPersonalisedUrl('/product-tour')).to.be.false;
+		expect(isPersonalisedUrl('/tour')).to.be.false;
 		expect(isPersonalisedUrl('/following/')).to.be.false;
 
 	});

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -30,13 +30,13 @@ describe('url personalising', function () {
 		expect(personaliseUrl(`/myft/saved-articles/${userId}`, userId)).to.equal(`/myft/saved-articles/${userId}`);
 		expect(personaliseUrl(`/myft/explore/${userId}`, userId)).to.equal(`/myft/explore/${userId}`);
 		expect(personaliseUrl(`/myft/alerts/${userId}`, userId)).to.equal(`/myft/alerts/${userId}`);
-		expect(personaliseUrl('/myft/product-tour', userId)).to.equal('/myft/product-tour');
 		expect(personaliseUrl('/myft/api/skdjfhksjd', userId)).to.equal('/myft/api/skdjfhksjd');
 
 		// legacy+immutable URLs
 		expect(personaliseUrl('/myft/my-news', userId)).to.equal('/myft/my-news');
 		expect(personaliseUrl('/myft/my-topics', userId)).to.equal('/myft/my-topics');
 		expect(personaliseUrl('/myft/preferences', userId)).to.equal('/myft/preferences');
+		expect(personaliseUrl('/myft/product-tour', userId)).to.equal('/myft/product-tour');
 
 		// a url with a non-user uuid in the query string
 		expect(personaliseUrl(`/myft/saved-articles?fragment=true&contentId=${articleId}`, userId)).to.equal(`/myft/saved-articles/${userId}?fragment=true&contentId=${articleId}`);

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -37,6 +37,7 @@ describe('url personalising', function () {
 		expect(personaliseUrl('/myft/my-topics', userId)).to.equal('/myft/my-topics');
 		expect(personaliseUrl('/myft/preferences', userId)).to.equal('/myft/preferences');
 		expect(personaliseUrl('/myft/product-tour', userId)).to.equal('/myft/product-tour');
+		expect(personaliseUrl('/myft/clippings', userId)).to.equal('/myft/clippings');
 
 		// a url with a non-user uuid in the query string
 		expect(personaliseUrl(`/myft/saved-articles?fragment=true&contentId=${articleId}`, userId)).to.equal(`/myft/saved-articles/${userId}?fragment=true&contentId=${articleId}`);


### PR DESCRIPTION
- Moves `/myft/product-tour` to the legacy URL list
- Adds `/myft/clippings` as a legacy URL

_Context:_ At the moment, the clippings pages are proxied, custom rendererings of the myFT (product-)tour 😱 . We’ll be moving the myFT tour over to the tour page app soon, so we’ll remove clippings’ dependency on it by adding this `/myft/clippings` route.