### PR TITLE
Add missing `__` in legacy regex

### DIFF
--- a/src/lib/is-legacy-url.js
+++ b/src/lib/is-legacy-url.js
@@ -1,1 +1,1 @@
-module.exports = path => /^\/myft\/(my-news|my-topics|preferences|product-tour|clippings)/.test(path);
+module.exports = path => /^\/(__)?myft\/(my-news|my-topics|preferences|product-tour|clippings)/.test(path);

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -37,6 +37,7 @@ describe('url personalising', function () {
 		expect(personaliseUrl('/myft/my-topics', userId)).to.equal('/myft/my-topics');
 		expect(personaliseUrl('/myft/preferences', userId)).to.equal('/myft/preferences');
 		expect(personaliseUrl('/myft/product-tour', userId)).to.equal('/myft/product-tour');
+		expect(personaliseUrl('/__myft/product-tour', userId)).to.equal('/myft/product-tour');
 		expect(personaliseUrl('/myft/clippings', userId)).to.equal('/myft/clippings');
 
 		// a url with a non-user uuid in the query string

--- a/tests/lib/personalise-url.spec.js
+++ b/tests/lib/personalise-url.spec.js
@@ -37,7 +37,7 @@ describe('url personalising', function () {
 		expect(personaliseUrl('/myft/my-topics', userId)).to.equal('/myft/my-topics');
 		expect(personaliseUrl('/myft/preferences', userId)).to.equal('/myft/preferences');
 		expect(personaliseUrl('/myft/product-tour', userId)).to.equal('/myft/product-tour');
-		expect(personaliseUrl('/__myft/product-tour', userId)).to.equal('/myft/product-tour');
+		expect(personaliseUrl('/__myft/product-tour', userId)).to.equal('/__myft/product-tour');
 		expect(personaliseUrl('/myft/clippings', userId)).to.equal('/myft/clippings');
 
 		// a url with a non-user uuid in the query string


### PR DESCRIPTION
I unwittingly removed it in the previous PR