### PR TITLE
Ensure production GET request content-length header is set to int

### DIFF
--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -58,7 +58,7 @@ class MyFtApi {
 		} else {
 
 			if(process && process.env.NODE_ENV === 'production') {
-				this.headers['Content-Length'] = '';
+				this.headers['Content-Length'] = 0;
 			}
 
 			Object.keys(data || {}).forEach(function (key) {


### PR DESCRIPTION
Over the last 4 days we've observed a high rate of [`413 PAYLOAD TOO LARGE`](https://httpstatuses.com/413) errors being thrown when apps are taking to the API via the client. After some tiring and testing diagnosis we isolated the issue to be with the `Content-Length` header value on the `GET` requests.

I am presuming something changed in Fastly's infrastructure or some intermediaries that didn't like content-length headers to exist with an empty value. Therefore correctly defaulting to `0` seems to have solved the problem. 

See #41 for further info as to why we needed this hack in the first place.

From the HTTP spec:

> The Content-Length entity-header field indicates the size of the entity-body, in decimal number of OCTETs, sent to the recipient. 

> Any Content-Length greater than or equal to zero is a valid value