### PR TITLE
duplicate traffic to neo3 test api

### DIFF
--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -70,6 +70,10 @@ class MyFtApi {
 			});
 		}
 
+		// fire and forget myft API load test fetch
+		const testMyFtApiUrl = `https://ft-next-myft-api.herokuapp.com/v3/${endpoint}${queryString}`;
+		fetch(testMyFtApiUrl, options)
+
 		return fetch(this.apiRoot + endpoint + queryString, options)
 			.then(res => {
 				if (res.status === 404) {


### PR DESCRIPTION
@dgem finally going to start sending some stuff your way!

Also @debugwand 

This captures all read/write traffic for on-site myFT interactions, e.g. reading feed, following, updating prefs.

Ideally this would be behind a flag, but the plumbing for passing flags to the myft-client isn't yet set up, and it's a rabbit hole I'd rather avoid. Confident this is low risk.
