### PR TITLE
Add a bypass-maintenenance header when not in prod

### DIFF
--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -14,8 +14,8 @@ const defaultHeaders = {
 };
 
 const envHeaders = {};
-if(process.env.NODE_ENV !== 'production') {
-	envHeaders['ft-bypass-maintenance-mode-for-get'] = true;
+if (process.env.BYPASS_MYFT_MAINTENANCE_MODE) {
+	envHeaders['ft-bypass-myft-maintenance-mode'] = true;
 }
 
 class MyFtApi {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -15,7 +15,7 @@ const defaultHeaders = {
 
 const envHeaders = {};
 if (process.env.BYPASS_MYFT_MAINTENANCE_MODE) {
-	envHeaders['ft-bypass-myft-maintenance-mode'] = true;
+	envHeaders['ft-bypass-myft-maintenance-mode'] = 'true';
 }
 
 class MyFtApi {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -1,6 +1,3 @@
-'use strict';
-
-/*global Buffer*/
 const fetchres = require('fetchres');
 const BlackHoleStream = require('black-hole-stream');
 
@@ -12,15 +9,27 @@ const lib = {
 	isValidUuid: require('./lib/is-valid-uuid')
 };
 
+const defaultHeaders = {
+	'Content-Type': 'application/json',
+};
+
+const envHeaders = {};
+if(process.env.NODE_ENV !== 'production') {
+	envHeaders['ft-bypass-maintenance-mode-for-get'] = true;
+}
+
 class MyFtApi {
 	constructor (opts) {
 		if (!opts.apiRoot) {
 			throw 'Myft API  must be constructed with an api root';
 		}
 		this.apiRoot = opts.apiRoot;
-		this.headers = Object.assign({
-			'Content-Type': 'application/json',
-		}, opts.headers);
+
+		this.headers = Object.assign({},
+			opts.headers,
+			defaultHeaders,
+			envHeaders
+		);
 	}
 
 	fetchJson (method, endpoint, data, opts) {
@@ -57,7 +66,7 @@ class MyFtApi {
 			}
 		} else {
 
-			if (process && process.env.NODE_ENV === 'production') {
+			if (process.env.NODE_ENV === 'production') {
 				this.headers['Content-Length'] = 0;
 			}
 

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -26,9 +26,9 @@ class MyFtApi {
 		this.apiRoot = opts.apiRoot;
 
 		this.headers = Object.assign({},
-			opts.headers,
 			defaultHeaders,
-			envHeaders
+			envHeaders,
+			opts.headers
 		);
 	}
 

--- a/test/browser/myft-client.spec.js
+++ b/test/browser/myft-client.spec.js
@@ -518,7 +518,7 @@ describe('endpoints', function () {
 					expect(evt.detail.count).to.equal(3);
 					expect(evt.detail.items[0].uuid = '00000000-0000-0000-0000-000000000000');
 				});
-			})
+			});
 
 		});
 
@@ -564,7 +564,7 @@ describe('endpoints', function () {
 					let callPromiseResult = results[0];
 					expect(callPromiseResult.subject).to.equal('12345');
 				});
-			})
+			});
 		});
 
 		it('can remove a saved', function (done) {

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -94,7 +94,7 @@ describe('myFT node API', () => {
 
 		it('should pass a flag to bypass maintenance mode', () => {
 			return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
-				expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.be.true;
+				expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.equal('true');
 			});
 		});
 

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -6,41 +6,7 @@ fetchMock.get('*', []);
 
 describe('myFT node API', () => {
 
-	describe('in prod environment', () => {
-
-		let MyFtApi;
-		let myFtApi;
-
-		let previousNodeEnv;
-
-		beforeEach(function () {
-			previousNodeEnv = process.env.NODE_ENV;
-			process.env.NODE_ENV = 'production';
-
-			delete require.cache[require.resolve('../../src/myft-api')];
-			MyFtApi = require('../../src/myft-api');
-			myFtApi = new MyFtApi({
-				apiRoot: 'https://test-api-route.com/',
-				headers: {
-					'X-API-KEY': 'adasd'
-				}
-			});
-		});
-
-		afterEach(function () {
-			fetchMock.reset();
-			process.env.NODE_ENV = previousNodeEnv;
-		});
-
-		it('should NOT pass a flag to bypass maintenance mode', () => {
-			return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
-				expect(fetchMock.lastOptions('*').headers['ft-bypass-maintenance-mode-for-get']).to.not.be.true;
-			});
-		});
-
-	});
-
-	describe('in non-prod environment', () => {
+	describe('default environment', () => {
 
 		const MyFtApi = require('../../src/myft-api');
 		const myFtApi = new MyFtApi({
@@ -92,11 +58,45 @@ describe('myFT node API', () => {
 				});
 			});
 
-			it('should pass a flag to bypass maintenance mode (as we\'re not in prod)', () => {
+			it('should not pass a flag to bypass maintenance mode', () => {
 				return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
-					expect(fetchMock.lastOptions('*').headers['ft-bypass-maintenance-mode-for-get']).to.be.true;
+					expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.not.be.true;
 				});
 			});
 		});
+	});
+
+	describe('when BYPASS_MYFT_MAINTENANCE_MODE flag is set', () => {
+
+		let MyFtApi;
+		let myFtApi;
+
+		let previousBypassMaintenanceMode;
+
+		beforeEach(function () {
+			previousBypassMaintenanceMode = process.env.BYPASS_MYFT_MAINTENANCE_MODE;
+			process.env.BYPASS_MYFT_MAINTENANCE_MODE = true;
+
+			delete require.cache[require.resolve('../../src/myft-api')];
+			MyFtApi = require('../../src/myft-api');
+			myFtApi = new MyFtApi({
+				apiRoot: 'https://test-api-route.com/',
+				headers: {
+					'X-API-KEY': 'adasd'
+				}
+			});
+		});
+
+		afterEach(function () {
+			fetchMock.reset();
+			process.env.BYPASS_MYFT_MAINTENANCE_MODE = previousBypassMaintenanceMode;
+		});
+
+		it('should pass a flag to bypass maintenance mode', () => {
+			return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
+				expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.be.true;
+			});
+		});
+
 	});
 });

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -6,53 +6,96 @@ fetchMock.get('*', []);
 
 describe('myFT node API', () => {
 
-	const MyFtApi = require('../../src/myft-api');
-	const myFtApi = new MyFtApi({
-		apiRoot: 'https://test-api-route.com/',
-		headers: {
-			'X-API-KEY': 'adasd'
-		}
-	});
+	describe('in prod environment', () => {
 
-	describe('url personalising', function () {
-		it('should be possible to personalise a url', function () {
+		let MyFtApi;
+		let myFtApi;
 
-			const testUuid = '00000000-0000-0000-0000-000000000000';
+		let previousNodeEnv;
 
-			expect(myFtApi.personaliseUrl('/myft', testUuid)).to.equal(`/myft/${testUuid}`);
-			expect(myFtApi.personaliseUrl(`/myft/${testUuid}`, testUuid)).to.equal(`/myft/${testUuid}`);
-		});
-	});
+		beforeEach(function () {
+			previousNodeEnv = process.env.NODE_ENV;
+			process.env.NODE_ENV = 'production';
 
-
-	describe('identifying personalised URLs', function () {
-		it('should identify between personalised urls and not personalised urls', function () {
-			expect(myFtApi.isPersonalisedUrl('/myft/00000000-0000-0000-0000-000000000000')).to.be.true;
-			expect(myFtApi.isPersonalisedUrl('/myft/following/')).to.be.false;
-		});
-	});
-
-	describe('identifying immutable URLs', function () {
-		it('should identify between immutable urls and mutable urls', function () {
-			expect(myFtApi.isImmutableUrl('/myft/00000000-0000-0000-0000-000000000000')).to.be.true;
-			expect(myFtApi.isImmutableUrl('/myft/following/')).to.be.false;
-		});
-	});
-
-	describe('getting a relationship', function () {
-
-		it('should request the API', () => {
-			return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
-				expect(fetchMock.lastUrl('*')).to.equal('https://test-api-route.com/user/userId/followed/concept');
+			delete require.cache[require.resolve('../../src/myft-api')];
+			MyFtApi = require('../../src/myft-api');
+			myFtApi = new MyFtApi({
+				apiRoot: 'https://test-api-route.com/',
+				headers: {
+					'X-API-KEY': 'adasd'
+				}
 			});
 		});
 
-		it('should accept pagination parameters', () => {
-			return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept', {
-				page: 2,
-				limit: 10
-			}).then(() => {
-				expect(fetchMock.lastUrl('*')).to.equal('https://test-api-route.com/user/userId/followed/concept?page=2&limit=10');
+		afterEach(function () {
+			fetchMock.reset();
+			process.env.NODE_ENV = previousNodeEnv;
+		});
+
+		it('should NOT pass a flag to bypass maintenance mode', () => {
+			return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
+				expect(fetchMock.lastOptions('*').headers['ft-bypass-maintenance-mode-for-get']).to.not.be.true;
+			});
+		});
+
+	});
+
+	describe('in non-prod environment', () => {
+
+		const MyFtApi = require('../../src/myft-api');
+		const myFtApi = new MyFtApi({
+			apiRoot: 'https://test-api-route.com/',
+			headers: {
+				'X-API-KEY': 'adasd'
+			}
+		});
+
+		describe('url personalising', function () {
+			it('should be possible to personalise a url', function () {
+
+				const testUuid = '00000000-0000-0000-0000-000000000000';
+
+				expect(myFtApi.personaliseUrl('/myft', testUuid)).to.equal(`/myft/${testUuid}`);
+				expect(myFtApi.personaliseUrl(`/myft/${testUuid}`, testUuid)).to.equal(`/myft/${testUuid}`);
+			});
+		});
+
+
+		describe('identifying personalised URLs', function () {
+			it('should identify between personalised urls and not personalised urls', function () {
+				expect(myFtApi.isPersonalisedUrl('/myft/00000000-0000-0000-0000-000000000000')).to.be.true;
+				expect(myFtApi.isPersonalisedUrl('/myft/following/')).to.be.false;
+			});
+		});
+
+		describe('identifying immutable URLs', function () {
+			it('should identify between immutable urls and mutable urls', function () {
+				expect(myFtApi.isImmutableUrl('/myft/00000000-0000-0000-0000-000000000000')).to.be.true;
+				expect(myFtApi.isImmutableUrl('/myft/following/')).to.be.false;
+			});
+		});
+
+		describe('getting a relationship', function () {
+
+			it('should request the API', () => {
+				return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
+					expect(fetchMock.lastUrl('*')).to.equal('https://test-api-route.com/user/userId/followed/concept');
+				});
+			});
+
+			it('should accept pagination parameters', () => {
+				return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept', {
+					page: 2,
+					limit: 10
+				}).then(() => {
+					expect(fetchMock.lastUrl('*')).to.equal('https://test-api-route.com/user/userId/followed/concept?page=2&limit=10');
+				});
+			});
+
+			it('should pass a flag to bypass maintenance mode (as we\'re not in prod)', () => {
+				return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
+					expect(fetchMock.lastOptions('*').headers['ft-bypass-maintenance-mode-for-get']).to.be.true;
+				});
 			});
 		});
 	});


### PR DESCRIPTION
A slightly more interesting PR. This is a part of an attempt to fix our problem wherein the builds fail when maintenance mode is on. Specifically, this will enable the myft-page smoke tests to pass.

When in production mode, add a header to myFT API requests specifying that we want to ignore maintenance mode. This header will only have an affect on `GET` requests.

Here's a _very_ rough drawing of the problem and my proposed solution:

![fixing the tests in maintenence mode](https://user-images.githubusercontent.com/4622378/29715094-b909cf8a-899d-11e7-9932-841ea644fe19.png)


I've called the flag `ft-bypass-maintenance-mode-for-get` for descriptiveness' sake but I'm not happy with this at all so any suggestions welcome.


 🐿 v2.5.16