### PR TITLE
Add new method to get topics based on reading history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 /.idea/
 /bower_components/
 /node_modules/
-
 .editorconfig
 .eslintrc.js
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Remove an array of notifications from the user's myFT. If force is falsy a check
 
 Mark an array of notifications as seen
 
+### .getConceptsFromReadingHistory(userUuid, spoorDeviceID)
+
+Returns an array of primary concepts from stories that have been read in the last 7 days.
+The stories that the used are based on a single user using a single device so both the user uuid and spoor device id are required.
+
 
 ### Events
 

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -133,6 +133,16 @@ class MyFtApi {
 		return this.fetchJson('POST', `purge/${actor}/${id}/${relationship}`, null, opts);
 	}
 
+	getConceptsFromReadingHistory (userUuid, spoorDeviceId) {
+		const headers = Object.assign(this.headers,
+			{
+				'ft-spoor-id': spoorDeviceId,
+				'ft-user-uuid': userUuid
+			});
+
+		return this.fetchJson('GET', `next/history/${userUuid}`, null, {headers})
+	}
+
 	personaliseUrl (url, uuid) {
 		return lib.personaliseUrl(url, uuid);
 	}


### PR DESCRIPTION
Talk to the new endpoint on myft-api that returns topics based on the
articles you have read recently
 🐿 v2.5.16