### PR TITLE
add the topic limit value to the query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ has('saved', 'content','00000000-0000-0000-0000-000000000003').then(function(has
 
 ### .notifications.clear(uuids, force)
 
-Remove an array of notifications from the user's myFT. If force is falsy a check will be run to make sure the notification exists before sending the request to clear it
+Remove an array of notifications from the user's myFT. If force is falsey a check will be run to make sure the notification exists before sending the request to clear it
 
 ### .notifications.markAsSeen(uuids)
 
 Mark an array of notifications as seen
 
-### .getConceptsFromReadingHistory(userUuid, spoorDeviceID)
+### .getConceptsFromReadingHistory(userUuid, spoorDeviceID, limit)
 
-Returns an array of primary concepts from stories that have been read in the last 7 days.
+Returns an array of primary concepts from stories that have been read in the last 7 days. Array length will be <= limit.
 The stories that the used are based on a single user using a single device so both the user uuid and spoor device id are required.
 
 

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -133,14 +133,14 @@ class MyFtApi {
 		return this.fetchJson('POST', `purge/${actor}/${id}/${relationship}`, null, opts);
 	}
 
-	getConceptsFromReadingHistory (userUuid, spoorDeviceId) {
+	getConceptsFromReadingHistory (userUuid, spoorDeviceId, limit) {
 		const headers = Object.assign(this.headers,
 			{
 				'ft-spoor-id': spoorDeviceId,
 				'ft-user-uuid': userUuid
 			});
 
-		return this.fetchJson('GET', `next/history/${userUuid}`, null, {headers});
+		return this.fetchJson('GET', `next/history/${userUuid}?limit=${limit}`, null, {headers});
 	}
 
 	personaliseUrl (url, uuid) {


### PR DESCRIPTION
 🐿 v2.5.16 Passes the topics limit though to the myft-api here: https://github.com/Financial-Times/next-myft-api/blob/master/server/v2/controllers/recommendation/ammit-device-history.js#L31