### PR TITLE
Merge headers so it doesn't just use passed in headers

### DIFF
--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -38,9 +38,12 @@ class MyFtApi {
 		let queryString = '';
 		let options = Object.assign({
 			method,
-			headers: this.headers,
 			credentials: 'include'
-		}, opts);
+		},
+		opts,
+		{
+			headers: this.headers
+		});
 
 		if (/undefined/.test(endpoint)) {
 			return Promise.reject('Request must not contain undefined. Invalid path: ' + endpoint);


### PR DESCRIPTION
Previously this was always using the option headers to overwrite the
default headers. Which meant if you passed in a header then the api key
header was removed.
