### PR TITLE
fix get items bug

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -195,7 +195,7 @@ class MyFtClient {
 	}
 
 	getItems (relationship, type) {
-		return this.loaded[`${relationship}.${type}`].items || [];
+		return this.loaded[`${relationship}.${type}`] && this.loaded[`${relationship}.${type}`].items || [];
 	}
 
 	personaliseUrl (url) {


### PR DESCRIPTION
make getItems safe if the relationship/type pair doesn't exist
 

🐿 v2.12.3