### PR TITLE
fix preinstall 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "([ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine; npx npm-force-resolutions)"
+    "preinstall": "([ \"$INIT_CWD\" != \"$PWD\" ] || (npm_config_yes=true npx check-engine; npx npm-force-resolutions))"
   },
   "volta": {
     "node": "16.14.2",


### PR DESCRIPTION
## Description

The command `npm-force-resolutions` in the `preinstall` step is meant only to be run for local package development. 