### PR TITLE
Ug-1022 create new public list method

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -185,14 +185,14 @@ class MyFtClient {
 		});
 	}
 
-	getListsContent() {
+	getListsContent () {
 		return this.fetchJson('GET', `${this.userId}/lists`)
 			.then((lists) => {
 				if (!lists) {
-					return emptyResponse
+					return emptyResponse;
 				}
-				return lists
-			})
+				return lists;
+			});
 	}
 
 	has (relationship, type, subject) {

--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -241,6 +241,13 @@ class MyFtClient {
 				return details;
 			});
 	}
+
+	getPublicList (listId) {
+		return this.fetchJson('GET', `public-list/${listId}`)
+			.catch((err) => {
+				throw new Error(err);
+			});
+	}
 }
 
 export default MyFtClient;

--- a/test/browser/fixtures/publicList.json
+++ b/test/browser/fixtures/publicList.json
@@ -1,0 +1,14 @@
+{
+    "id": "1001",
+    "name": "Test Reading List",
+    "articleData": [
+        {
+            "id": "001",
+            "title": "title 1"
+        },
+        {
+            "id": "002",
+            "title": "title 2"
+        }
+    ]
+}

--- a/test/browser/myft-client.spec.js
+++ b/test/browser/myft-client.spec.js
@@ -255,10 +255,10 @@ describe('endpoints', function () {
 
 		it('can return all lists and their contents', function (done) {
 			fetchStub.returns(mockFetch(fixtures.lists));
-			const contentUuid = '00000000-0000-0000-0000-000000000001'
+			const contentUuid = '00000000-0000-0000-0000-000000000001';
 
 			myFtClient.init().then(() => {
-				let callPromise = myFtClient.getListsContent()
+				let callPromise = myFtClient.getListsContent();
 				const firstNonLoadCall = fetchStub.args[3];
 				expect(firstNonLoadCall[0]).to.equal(`testRoot/${myFtClient.userId}/lists`);
 				expect(firstNonLoadCall[1].method).to.equal('GET');
@@ -268,7 +268,7 @@ describe('endpoints', function () {
 					expect(callPromiseResult.items[0].uuid).to.equal(userUuid);
 					expect(callPromiseResult.items[0].content[0].uuid).to.equal(contentUuid);
 					done();
-				})
+				});
 			}).catch(done);
 		});
 

--- a/test/browser/myft-client.spec.js
+++ b/test/browser/myft-client.spec.js
@@ -8,7 +8,8 @@ const fixtures = {
 	follow: require('./fixtures/follow.json'),
 	nofollow: require('./fixtures/nofollow.json'),
 	saved: require('./fixtures/saved.json'),
-	lists: require('./fixtures/lists.json')
+	lists: require('./fixtures/lists.json'),
+	publicList: require('./fixtures/publicList.json')
 };
 
 const userUuid = '00000000-0000-0000-0000-000000000000';
@@ -645,6 +646,22 @@ describe('endpoints', function () {
 			});
 		});
 
+	});
+
+	describe('public list browsing', function () {
+		it('can get all saved articles', function (done) {
+			fetchStub.returns(mockFetch(fixtures.publicList));
+
+			myFtClient.init().then(function () {
+				return myFtClient.getPublicList('some-list-id').then(list => {
+					expect(list.articleData.length).to.equal(2);
+					expect(list.articleData[0].id).to.equal('001');
+					expect(list.articleData[0].title).to.equal('title 1');
+					expect(list.id).to.equal('1001');
+					done();
+				});
+			}).catch(done);
+		});
 	});
 
 });


### PR DESCRIPTION
This PR is to create a myftClient method for the [pr](https://github.com/Financial-Times/next-myft-proxy/pull/450) that created a new endpoint in myft-proxy.

Clients will use it to request a public list and its contents, for use in the browsable lists component that will sit on the right hand rail in articles on an AB test we'll be running.  Please see [our epic](https://financialtimes.atlassian.net/browse/UG-794) for further details.

