### PR TITLE
Fix: Check for secure session instead of insecure session

### DIFF
--- a/src/myft-client.js
+++ b/src/myft-client.js
@@ -29,7 +29,7 @@ class MyFtClient {
 		}
 		this.initialised = true;
 
-		const anonymousUser = !(/FTSession=/.test(document.cookie));
+		const anonymousUser = !(/FTSession_s=/.test(document.cookie));
 		if (anonymousUser) {
 			return Promise.reject('No session cookie found');
 		}

--- a/test/browser/myft-client.spec.js
+++ b/test/browser/myft-client.spec.js
@@ -66,7 +66,7 @@ describe('Initialising', function () {
 	});
 
 	it('fetches a guid from the session', function (done) {
-		document.cookie = 'FTSession=12345';
+		document.cookie = 'FTSession_s=12345';
 		sinon.stub(session, 'uuid').resolves({uuid: userUuid});
 		let myFtClient = new MyFtClient({
 			apiRoot: 'testRoot/'
@@ -83,7 +83,7 @@ describe('Initialising', function () {
 	});
 
 	it('exits if no or invalid guid', function (done) {
-		document.cookie = 'FTSession=bad';
+		document.cookie = 'FTSession_s=bad';
 		sinon.stub(session, 'uuid').rejects();
 		let myFtClient = new MyFtClient({
 			apiRoot: 'testRoot/'
@@ -97,7 +97,7 @@ describe('Initialising', function () {
 	});
 
 	it('exits if undefined guid', function (done) {
-		document.cookie = 'FTSession=bad';
+		document.cookie = 'FTSession_s=bad';
 		sinon.stub(session, 'uuid').resolves({ uuid: undefined });
 		let myFtClient = new MyFtClient({
 			apiRoot: 'testRoot/'
@@ -110,7 +110,7 @@ describe('Initialising', function () {
 			});
 	});
 
-	it('exits early if no FTSession token in cookie', function (done) {
+	it('exits early if no FTSession_s token in cookie', function (done) {
 		document.cookie = '';
 
 		let myFtClient = new MyFtClient({
@@ -132,7 +132,7 @@ describe('Requesting relationships on initialisation', function () {
 	let fetchStub;
 	let myFtClient;
 	beforeEach(function () {
-		document.cookie = 'FTSession=12345;';
+		document.cookie = 'FTSession_s=12345;';
 		fetchStub = sinon.stub(window, 'fetch');
 		sinon.stub(session, 'uuid').resolves({ uuid: userUuid });
 		myFtClient = new MyFtClient({
@@ -194,7 +194,7 @@ describe('Requesting relationships on initialisation', function () {
 
 describe('url personalising', function () {
 	it('should be possible to personalise a url', function (done) {
-		document.cookie = 'FTSession=12345; FT_U=_EID=12324_PID=4011101642_TIME=%5BWed%2C+04-Mar-2015+11%3A49%3A49+GMT%5D_RI=0_I=0_';
+		document.cookie = 'FTSession_s=12345; FT_U=_EID=12324_PID=4011101642_TIME=%5BWed%2C+04-Mar-2015+11%3A49%3A49+GMT%5D_RI=0_I=0_';
 		sinon.stub(session, 'uuid').resolves({ uuid: userUuid });
 		let myFtClient = new MyFtClient({
 			apiRoot: 'testRoot/'
@@ -227,7 +227,7 @@ describe('endpoints', function () {
 	let fetchStub;
 	let myFtClient;
 	beforeEach(function () {
-		document.cookie = 'FTSession=12345; FT_U=_EID=12324_PID=4011101642_TIME=%5BWed%2C+04-Mar-2015+11%3A49%3A49+GMT%5D_RI=0_I=0_';
+		document.cookie = 'FTSession_s=12345; FT_U=_EID=12324_PID=4011101642_TIME=%5BWed%2C+04-Mar-2015+11%3A49%3A49+GMT%5D_RI=0_I=0_';
 		fetchStub = sinon.stub(window, 'fetch');
 		sinon.stub(session, 'uuid').resolves({ uuid: userUuid });
 		myFtClient = new MyFtClient({


### PR DESCRIPTION
This check was checking for the insecure session token when we should now be using secure sessions only. Its also exiting early before the use of next-session-client which uses the secure session.

This was causing issues for internal users who were masquerading as users and the insecure session token wasn't present.

## Screenshots

**Masquerading console error**
<img width="397" alt="Screenshot 2023-10-24 at 16 45 15" src="https://github.com/Financial-Times/next-myft-client/assets/524573/32c8f881-8c70-45b1-b4be-7e03063a2f8b">

**Masquerading session cookies (No insecure session)**
<img width="189" alt="Screenshot 2023-10-24 at 16 09 51" src="https://github.com/Financial-Times/next-myft-client/assets/524573/4575e0e4-6f77-441e-9c48-7d5cd2f2c360">

## Notes

Regarding what I mentioned about this exiting early before next-session-client, I think this check might be redundant as [next-session-client handles this exiting earlier for us](https://github.com/Financial-Times/next-session-client/blob/main/main.js#L22-L25). However I didn't want to remove this right now I would like to get a fix in quickly for this user and I am not responsible for this codebase and therefore not aware of what knock on effect that could have
