### PR TITLE
CON-2889 - add 'overrideHeaders' arg to allow clients to customize requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Remove an array of notifications from the user's myFT. If force is falsey a chec
 
 Mark an array of notifications as seen
 
-### .getConceptsFromReadingHistory(userUuid, limit, overrideHeaders)
+### .getConceptsFromReadingHistory(userUuid, limit, options, overrideHeaders)
 
 Returns an array of primary concepts from stories that have been read in the last 7 days. Array length will be <= limit.
 The stories used are based on a single user across devices.

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Remove an array of notifications from the user's myFT. If force is falsey a chec
 
 Mark an array of notifications as seen
 
-### .getConceptsFromReadingHistory(userUuid, limit)
+### .getConceptsFromReadingHistory(userUuid, limit, overrideHeaders)
 
 Returns an array of primary concepts from stories that have been read in the last 7 days. Array length will be <= limit.
 The stories used are based on a single user across devices.
 
-### .getArticlesFromReadingHistory(userUuid, daysBack, options)
+### .getArticlesFromReadingHistory(userUuid, daysBack, options, overrideHeaders)
 
 Returns an array of article uuids that have been read in the given number of days.
 The `daysBack` argument should be supplied as a negative value, i.e. `-7` for the past 7 days.

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -136,20 +136,20 @@ class MyFtApi {
 		return this.fetchJson('POST', `purge/${actor}/${id}/${relationship}`, null, opts);
 	}
 
-	getConceptsFromReadingHistory (userUuid, limit) {
+	getConceptsFromReadingHistory (userUuid, limit, overrideHeaders = {}) {
 		const headers = Object.assign(this.headers,
 			{
 				'ft-user-uuid': userUuid
-			});
+			}, overrideHeaders);
 
 		return this.fetchJson('GET', `next/user/${userUuid}/history/topics?limit=${limit}`, null, {headers});
 	}
 
-	getArticlesFromReadingHistory (userUuid, daysBack = -7, opts = {}) {
+	getArticlesFromReadingHistory (userUuid, daysBack = -7, opts = {}, overrideHeaders = {}) {
 		const headers = Object.assign(this.headers,
 			{
 				'ft-user-uuid': userUuid
-			});
+			}, overrideHeaders);
 
 		return this.fetchJson('GET', `next/user/${userUuid}/history/articles?limit=${daysBack}`, null, Object.assign({ timeout: 3000 }, opts, { headers }));
 	}

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -136,13 +136,13 @@ class MyFtApi {
 		return this.fetchJson('POST', `purge/${actor}/${id}/${relationship}`, null, opts);
 	}
 
-	getConceptsFromReadingHistory (userUuid, limit, overrideHeaders = {}) {
+	getConceptsFromReadingHistory (userUuid, limit, opts = {}, overrideHeaders = {}) {
 		const headers = Object.assign(this.headers,
 			{
 				'ft-user-uuid': userUuid
 			}, overrideHeaders);
 
-		return this.fetchJson('GET', `next/user/${userUuid}/history/topics?limit=${limit}`, null, {headers});
+		return this.fetchJson('GET', `next/user/${userUuid}/history/topics?limit=${limit}`, null, Object.assign(opts, { headers }));
 	}
 
 	getArticlesFromReadingHistory (userUuid, daysBack = -7, opts = {}, overrideHeaders = {}) {


### PR DESCRIPTION
## Description

[CON-2889](https://financialtimes.atlassian.net/browse/CON-2889)

I'm doing an investigation on why `next-myft-api` has so many timeouts that triggers many alerts in that API.
In this [spreadsheet](https://docs.google.com/spreadsheets/d/1LK2Nb4BuwLIxqZxdoCvOz-LRz3ZUz6CFdwokGps0MCQ/edit?pli=1#gid=433189948) you can see a list of the next-myft-api endpoints that got requests in a small period of time and the response codes. Only the `/history/articles` and `/history/topics` endpoints have a big amount of failed requests. Unfortunately, I still can't identify where these requests come from.

This library is used by `next-api` to perform requests to these 2 endpoints. Unfortunately, the client can't add other headers like `x-origin-system-id`. In this PR, I am:
- adding a new arg so we can add/override any header
- set a timeout for getConceptsFromReadingHistory()

you can see [here](https://github.com/Financial-Times/next-personalised-feed-api/pull/312/files) a similar PR part of this investigation 

After this PR is merged, I'll open a PR to update next-api [here](https://github.com/Financial-Times/next-api/blob/1daa73d61d6e5e56ef25625b83f4c24600a422dc/server/backends/my-ft.js#L53) to add the `x-origin-system-id` header

[CON-2889]: https://financialtimes.atlassian.net/browse/CON-2889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ