### PR TITLE
CON-3353: Pass headers to myft api requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "chai": "^4.3.8",
         "check-engine": "^1.12.0",
         "dotcom-tool-kit": "^3.4.5",
-        "fetch-mock": "^5.12.2",
+        "fetch-mock": "^6.5.2",
         "husky": "^0.14.1",
         "isomorphic-fetch": "^2.0.0",
         "karma": "^6.4.2",
@@ -2645,6 +2645,23 @@
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
       }
+    },
+    "node_modules/babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      }
+    },
+    "node_modules/babel-polyfill/node_modules/regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==",
+      "dev": true
     },
     "node_modules/babel-preset-env": {
       "version": "1.7.0",
@@ -5626,15 +5643,25 @@
       "dev": true
     },
     "node_modules/fetch-mock": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-5.13.1.tgz",
-      "integrity": "sha512-eWUo2KI4sRGnRu8tKELCBfasALM5BfvrCxdI7J02j3eUM9mf+uYzJkURA0PSn/29JVapVrYFm+z+9XijXu1PdA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.5.2.tgz",
+      "integrity": "sha512-EIvbpCLBTYyDLu4HJiqD7wC8psDwTUaPaWXNKZbhNO/peUYKiNp5PkZGKRJtnTxaPQu71ivqafvjpM7aL+MofQ==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "glob-to-regexp": "^0.3.0",
-        "node-fetch": "^1.3.3",
-        "path-to-regexp": "^1.7.0"
+        "babel-polyfill": "^6.26.0",
+        "glob-to-regexp": "^0.4.0",
+        "path-to-regexp": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
+    },
+    "node_modules/fetch-mock/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
     },
     "node_modules/fetchres": {
       "version": "1.7.2",
@@ -6093,9 +6120,9 @@
       }
     },
     "node_modules/glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
     "node_modules/global-agent": {
@@ -13083,13 +13110,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/watchpack/node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -13229,13 +13249,6 @@
       "engines": {
         "node": ">=0.8.x"
       }
-    },
-    "node_modules/webpack/node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/webpack/node_modules/picocolors": {
       "version": "1.0.0",
@@ -15802,6 +15815,25 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
@@ -18239,14 +18271,22 @@
       "dev": true
     },
     "fetch-mock": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-5.13.1.tgz",
-      "integrity": "sha512-eWUo2KI4sRGnRu8tKELCBfasALM5BfvrCxdI7J02j3eUM9mf+uYzJkURA0PSn/29JVapVrYFm+z+9XijXu1PdA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.5.2.tgz",
+      "integrity": "sha512-EIvbpCLBTYyDLu4HJiqD7wC8psDwTUaPaWXNKZbhNO/peUYKiNp5PkZGKRJtnTxaPQu71ivqafvjpM7aL+MofQ==",
       "dev": true,
       "requires": {
-        "glob-to-regexp": "^0.3.0",
-        "node-fetch": "^1.3.3",
-        "path-to-regexp": "^1.7.0"
+        "babel-polyfill": "^6.26.0",
+        "glob-to-regexp": "^0.4.0",
+        "path-to-regexp": "^2.2.1"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        }
       }
     },
     "fetchres": {
@@ -18596,9 +18636,9 @@
       }
     },
     "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
     "global-agent": {
@@ -24068,15 +24108,6 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
-      },
-      "dependencies": {
-        "glob-to-regexp": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-          "dev": true,
-          "peer": true
-        }
       }
     },
     "webidl-conversions": {
@@ -24154,13 +24185,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
           "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-          "dev": true,
-          "peer": true
-        },
-        "glob-to-regexp": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
           "dev": true,
           "peer": true
         },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chai": "^4.3.8",
     "check-engine": "^1.12.0",
     "dotcom-tool-kit": "^3.4.5",
-    "fetch-mock": "^5.12.2",
+    "fetch-mock": "^6.5.2",
     "husky": "^0.14.1",
     "isomorphic-fetch": "^2.0.0",
     "karma": "^6.4.2",

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -14,7 +14,7 @@ const defaultHeaders = {
 };
 
 const envHeaders = {};
-if (process.env.BYPASS_MYFT_MAINTENANCE_MODE) {
+if (process.env.BYPASS_MYFT_MAINTENANCE_MODE === 'true') {
 	envHeaders['ft-bypass-myft-maintenance-mode'] = 'true';
 }
 

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -36,14 +36,18 @@ class MyFtApi {
 		opts = opts || {};
 
 		let queryString = '';
-		let options = Object.assign({
+
+		const headers = {
+			...this.headers,
+			...opts.headers
+		};
+
+		let options = {
 			method,
-			credentials: 'include'
-		},
-		opts,
-		{
-			headers: this.headers
-		});
+			credentials: 'include',
+			...opts,
+			headers
+		};
 
 		if (/undefined/.test(endpoint)) {
 			return Promise.reject(new Error('Request must not contain undefined. Invalid path: ' + endpoint));
@@ -137,30 +141,29 @@ class MyFtApi {
 	}
 
 	getConceptsFromReadingHistory (userUuid, limit, opts = {}, overrideHeaders = {}) {
-		const headers = Object.assign(this.headers,
-			{
-				'ft-user-uuid': userUuid
-			}, overrideHeaders);
-
-		return this.fetchJson('GET', `next/user/${userUuid}/history/topics?limit=${limit}`, null, Object.assign(opts, { headers }));
+		const optsModified = {
+			...opts,
+			headers: { 'ft-user-uuid': userUuid, ...overrideHeaders }
+		};
+		return this.fetchJson('GET', `next/user/${userUuid}/history/topics?limit=${limit}`, null, optsModified);
 	}
 
 	getArticlesFromReadingHistory (userUuid, daysBack = -7, opts = {}, overrideHeaders = {}) {
-		const headers = Object.assign(this.headers,
-			{
-				'ft-user-uuid': userUuid
-			}, overrideHeaders);
-
-		return this.fetchJson('GET', `next/user/${userUuid}/history/articles?limit=${daysBack}`, null, Object.assign({ timeout: 3000 }, opts, { headers }));
+		const optsModified = {
+			timeout: 3000,
+			...opts,
+			headers: { 'ft-user-uuid': userUuid, ...overrideHeaders }
+		};
+		return this.fetchJson('GET', `next/user/${userUuid}/history/articles?limit=${daysBack}`, null, optsModified);
 	}
 
 	getUserLastSeenTimestamp (userUuid, opts = {}) {
-		const headers = Object.assign(this.headers,
-			{
-				'ft-user-uuid': userUuid
-			});
-
-		return this.fetchJson('GET', `next/user/${userUuid}/last-seen`, null, Object.assign({ timeout: 3000 }, opts, { headers }));
+		const optsModified = {
+			timeout: 3000,
+			...opts,
+			headers: { 'ft-user-uuid': userUuid, ...opts.headers }
+		};
+		return this.fetchJson('GET', `next/user/${userUuid}/last-seen`, null, optsModified);
 	}
 
 	personaliseUrl (url, uuid) {

--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -60,12 +60,10 @@ class MyFtApi {
 
 			// fiddle content length header to appease Fastly
 			if (process.env.NODE_ENV === 'production') {
-
 				// Fastly requires that empty requests have an empty object for a body and local API requires that
 				// they don't
 				options.body = JSON.stringify(data || {});
-
-				this.headers['Content-Length'] = Buffer.byteLength(options.body);
+				options.headers['Content-Length'] = Buffer.byteLength(options.body);
 
 			} else {
 				options.body = data ? JSON.stringify(data) : null;
@@ -73,7 +71,7 @@ class MyFtApi {
 		} else {
 
 			if (process.env.NODE_ENV === 'production') {
-				this.headers['Content-Length'] = 0;
+				options.headers['Content-Length'] = 0;
 			}
 
 			Object.keys(data || {}).forEach(function (key) {

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -55,6 +55,22 @@ describe('myFT node API', () => {
 		const defaultHeaders = { 'Content-Type': 'application/json' };
 		const optsHeaders = { 'x-opts-header': 'x-opts-header-value' };
 
+		it('should have correct default headers', () => {
+			myFtApi = new MyFtApi({ apiRoot: 'https://test-api-route.com/' });
+			expect(myFtApi.headers).to.deep.equal(defaultHeaders);
+		});
+
+		it('should set headers when it is provided', () => {
+			myFtApi = new MyFtApi({
+				apiRoot: 'https://test-api-route.com/',
+				headers: optsHeaders
+			});
+			expect(myFtApi.headers).to.deep.equal({
+				...defaultHeaders,
+				...optsHeaders
+			});
+		});
+
 		it('should not pass a flag to bypass maintenance mode', () => {
 			return myFtApi.getAllRelationship('user', userId, 'followed', 'concept').then(() => {
 				expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.not.be.true;

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -1,11 +1,9 @@
 require('isomorphic-fetch');
 const { expect } = require('chai');
 const fetchMock = require('fetch-mock');
+fetchMock.config.overwriteRoutes = true;
 
 const apiRoot = 'https://test-api-route.com/';
-
-fetchMock.get('*', []);
-fetchMock.put('*', []);
 
 describe('myFT node API', () => {
 
@@ -14,6 +12,10 @@ describe('myFT node API', () => {
 
 	const userId = '00000000-0000-0000-0000-000000000001';
 	const defaultHeaders = { 'Content-Type': 'application/json' };
+
+	beforeEach(() => {
+		fetchMock.get('*', []);
+	})
 
 	afterEach(function () {
 		fetchMock.reset();
@@ -92,6 +94,7 @@ describe('myFT node API', () => {
 		});
 
 		it('should not pass data as query params when method is not GET', () => {
+			fetchMock.put('*', []);
 			const endpoint = 'endpoint';
 			const paramOne = 'paramOneValue';
 			const paramTwo = 'paramTwoValue';
@@ -172,6 +175,7 @@ describe('myFT node API', () => {
 
 
 				it('should set Content-Length header with data length when method is not GET', () => {
+					fetchMock.put('*', []);
 					myFtApi = new MyFtApi({
 						apiRoot,
 						headers: optsHeaders

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -9,6 +9,7 @@ describe('myFT node API', () => {
 	let MyFtApi = require('../../src/myft-api');
 	let myFtApi = new MyFtApi({ apiRoot: 'https://test-api-route.com/' });
 	const userId = '00000000-0000-0000-0000-000000000001';
+	const defaultHeaders = { 'Content-Type': 'application/json' };
 
 	describe('Library functions', () => {
 		describe('url personalising', function () {
@@ -50,9 +51,32 @@ describe('myFT node API', () => {
 		});
 	});
 
+	describe('fetchJson', function () {
+		it('should pass correct opts to the API calls', () => {
+			const method = 'GET';
+			const timeout = 1406;
+			return myFtApi.fetchJson(method, 'endpoint', null, { timeout }).then(() => {
+				expect(fetchMock.lastOptions('*')).to.deep.equal({
+					method,
+					'credentials': 'include',
+					timeout,
+					headers: { ...defaultHeaders }
+				});
+			});
+		});
+
+		it('should reject when endpoint includes undefined', (done) => {
+			const endpoint = `endpoint/undefined/${userId}`;
+			myFtApi.fetchJson('GET', endpoint)
+				.catch(err => {
+					expect(err).to.deep.equal(new Error('Request must not contain undefined. Invalid path: ' + endpoint));
+					done();
+				});
+		});
+	});
+
 	describe('Headers', () => {
 
-		const defaultHeaders = { 'Content-Type': 'application/json' };
 		const optsHeaders = { 'x-opts-header': 'x-opts-header-value' };
 		const functionOptsHeaders = {
 			'x-function-opts-header': 'x-function-opts-header-value'
@@ -86,7 +110,7 @@ describe('myFT node API', () => {
 					apiRoot: 'https://test-api-route.com/',
 					headers: optsHeaders
 				});
-				return myFtApi.fetchJson('GET', 'endpont', null, { headers: functionOptsHeaders }).then(() => {
+				return myFtApi.fetchJson('GET', 'endpoint', null, { headers: functionOptsHeaders }).then(() => {
 					expect(fetchMock.lastOptions('*').headers).to.deep.equal({
 						...defaultHeaders,
 						...optsHeaders,

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -6,97 +6,103 @@ fetchMock.get('*', []);
 
 describe('myFT node API', () => {
 
-	describe('default environment', () => {
+	let MyFtApi = require('../../src/myft-api');
+	let myFtApi = new MyFtApi({ apiRoot: 'https://test-api-route.com/' });
+	const userId = '00000000-0000-0000-0000-000000000001';
 
-		const MyFtApi = require('../../src/myft-api');
-		const myFtApi = new MyFtApi({
-			apiRoot: 'https://test-api-route.com/',
-			headers: {
-				'X-API-KEY': 'adasd'
-			}
-		});
-
+	describe('Library functions', () => {
 		describe('url personalising', function () {
 			it('should be possible to personalise a url', function () {
-
-				const testUuid = '00000000-0000-0000-0000-000000000000';
-
-				expect(myFtApi.personaliseUrl('/myft', testUuid)).to.equal(`/myft/${testUuid}`);
-				expect(myFtApi.personaliseUrl(`/myft/${testUuid}`, testUuid)).to.equal(`/myft/${testUuid}`);
+				expect(myFtApi.personaliseUrl('/myft', userId)).to.equal(`/myft/${userId}`);
+				expect(myFtApi.personaliseUrl(`/myft/${userId}`, userId)).to.equal(`/myft/${userId}`);
 			});
 		});
 
-
 		describe('identifying personalised URLs', function () {
 			it('should identify between personalised urls and not personalised urls', function () {
-				expect(myFtApi.isPersonalisedUrl('/myft/00000000-0000-0000-0000-000000000000')).to.be.true;
+				expect(myFtApi.isPersonalisedUrl(`/myft/${userId}`)).to.be.true;
 				expect(myFtApi.isPersonalisedUrl('/myft/following/')).to.be.false;
 			});
 		});
 
 		describe('identifying immutable URLs', function () {
 			it('should identify between immutable urls and mutable urls', function () {
-				expect(myFtApi.isImmutableUrl('/myft/00000000-0000-0000-0000-000000000000')).to.be.true;
+				expect(myFtApi.isImmutableUrl(`/myft/${userId}`)).to.be.true;
 				expect(myFtApi.isImmutableUrl('/myft/following/')).to.be.false;
-			});
-		});
-
-		describe('getting a relationship', function () {
-
-			it('should request the API', () => {
-				return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
-					expect(fetchMock.lastUrl('*')).to.equal('https://test-api-route.com/user/userId/followed/concept');
-				});
-			});
-
-			it('should accept pagination parameters', () => {
-				return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept', {
-					page: 2,
-					limit: 10
-				}).then(() => {
-					expect(fetchMock.lastUrl('*')).to.equal('https://test-api-route.com/user/userId/followed/concept?page=2&limit=10');
-				});
-			});
-
-			it('should not pass a flag to bypass maintenance mode', () => {
-				return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
-					expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.not.be.true;
-				});
 			});
 		});
 	});
 
-	describe('when BYPASS_MYFT_MAINTENANCE_MODE flag is set', () => {
-
-		let MyFtApi;
-		let myFtApi;
-
-		let previousBypassMaintenanceMode;
-
-		beforeEach(function () {
-			previousBypassMaintenanceMode = process.env.BYPASS_MYFT_MAINTENANCE_MODE;
-			process.env.BYPASS_MYFT_MAINTENANCE_MODE = true;
-
-			delete require.cache[require.resolve('../../src/myft-api')];
-			MyFtApi = require('../../src/myft-api');
-			myFtApi = new MyFtApi({
-				apiRoot: 'https://test-api-route.com/',
-				headers: {
-					'X-API-KEY': 'adasd'
-				}
+	describe('getAllRelationship', function () {
+		it('should request the API', () => {
+			return myFtApi.getAllRelationship('user', userId, 'followed', 'concept').then(() => {
+				expect(fetchMock.lastUrl('*')).to.equal(`https://test-api-route.com/user/${userId}/followed/concept`);
 			});
 		});
 
-		afterEach(function () {
-			fetchMock.reset();
-			process.env.BYPASS_MYFT_MAINTENANCE_MODE = previousBypassMaintenanceMode;
+		it('should accept pagination parameters', () => {
+			return myFtApi.getAllRelationship('user', userId, 'followed', 'concept', {
+				page: 2,
+				limit: 10
+			}).then(() => {
+				expect(fetchMock.lastUrl('*')).to.equal(`https://test-api-route.com/user/${userId}/followed/concept?page=2&limit=10`);
+			});
 		});
+	});
 
-		it('should pass a flag to bypass maintenance mode', () => {
-			return myFtApi.getAllRelationship('user', 'userId', 'followed', 'concept').then(() => {
-				expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.equal('true');
+	describe('Headers', () => {
+
+		const defaultHeaders = { 'Content-Type': 'application/json' };
+		const optsHeaders = { 'x-opts-header': 'x-opts-header-value' };
+
+		it('should not pass a flag to bypass maintenance mode', () => {
+			return myFtApi.getAllRelationship('user', userId, 'followed', 'concept').then(() => {
+				expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.not.be.true;
 			});
 		});
 
+		describe('when BYPASS_MYFT_MAINTENANCE_MODE flag is set', () => {
+
+			let previousBypassMaintenanceMode;
+			const bypassMyftMaintenanceHeader = { 'ft-bypass-myft-maintenance-mode': 'true' };
+
+			beforeEach(function () {
+				previousBypassMaintenanceMode = process.env.BYPASS_MYFT_MAINTENANCE_MODE;
+				process.env.BYPASS_MYFT_MAINTENANCE_MODE = true;
+
+				delete require.cache[require.resolve('../../src/myft-api')];
+				MyFtApi = require('../../src/myft-api');
+			});
+
+			afterEach(function () {
+				fetchMock.reset();
+				process.env.BYPASS_MYFT_MAINTENANCE_MODE = previousBypassMaintenanceMode;
+			});
+
+
+			it('should set headers when it is provided', () => {
+				myFtApi = new MyFtApi({
+					apiRoot: 'https://test-api-route.com/',
+					headers: optsHeaders
+				});
+				expect(myFtApi.headers).to.deep.equal({
+					...defaultHeaders,
+					...optsHeaders,
+					...bypassMyftMaintenanceHeader
+				});
+			});
+
+			it('should pass a flag to bypass maintenance mode', () => {
+				myFtApi = new MyFtApi({ apiRoot: 'https://test-api-route.com/' });
+
+				return myFtApi.getAllRelationship('user', userId, 'followed', 'concept').then(() => {
+					expect(fetchMock.lastOptions('*').headers).to.deep.equal({
+						...defaultHeaders,
+						...bypassMyftMaintenanceHeader
+					});
+				});
+			});
+
+		});
 	});
 });

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -18,27 +18,27 @@ describe('myFT node API', () => {
 	const defaultHeaders = { 'Content-Type': 'application/json' };
 	const endpoint = `user/${userId}`;
 
-	afterEach(function () {
+	afterEach(() => {
 		fetchMock.reset();
 	});
 
 	describe('Library functions', () => {
-		describe('url personalising', function () {
-			it('should be possible to personalise a url', function () {
+		describe('url personalising', () => {
+			it('should be possible to personalise a url', () => {
 				expect(myFtApi.personaliseUrl('/myft', userId)).to.equal(`/myft/${userId}`);
 				expect(myFtApi.personaliseUrl(`/myft/${userId}`, userId)).to.equal(`/myft/${userId}`);
 			});
 		});
 
-		describe('identifying personalised URLs', function () {
-			it('should identify between personalised urls and not personalised urls', function () {
+		describe('identifying personalised URLs', () => {
+			it('should identify between personalised urls and not personalised urls', () => {
 				expect(myFtApi.isPersonalisedUrl(`/myft/${userId}`)).to.be.true;
 				expect(myFtApi.isPersonalisedUrl('/myft/following/')).to.be.false;
 			});
 		});
 
-		describe('identifying immutable URLs', function () {
-			it('should identify between immutable urls and mutable urls', function () {
+		describe('identifying immutable URLs', () => {
+			it('should identify between immutable urls and mutable urls', () => {
 				expect(myFtApi.isImmutableUrl(`/myft/${userId}`)).to.be.true;
 				expect(myFtApi.isImmutableUrl('/myft/following/')).to.be.false;
 			});
@@ -162,14 +162,14 @@ describe('myFT node API', () => {
 
 				const originalNodeEnv = process.env.NODE_ENV;
 
-				beforeEach(function () {
+				before(() => {
 					process.env.NODE_ENV = 'production';
 
 					delete require.cache[require.resolve('../../src/myft-api')];
 					MyFtApi = require('../../src/myft-api');
 				});
 
-				afterEach(function () {
+				after(() => {
 					process.env.NODE_ENV = originalNodeEnv;
 				});
 
@@ -245,17 +245,17 @@ describe('myFT node API', () => {
 
 		describe('when BYPASS_MYFT_MAINTENANCE_MODE flag is set', () => {
 
-			let originalBypassMaintenanceMode = process.env.BYPASS_MYFT_MAINTENANCE_MODE;
+			const originalBypassMaintenanceMode = process.env.BYPASS_MYFT_MAINTENANCE_MODE;
 			const bypassMyftMaintenanceHeader = { 'ft-bypass-myft-maintenance-mode': 'true' };
 
-			beforeEach(function () {
+			before(() => {
 				process.env.BYPASS_MYFT_MAINTENANCE_MODE = true;
 
 				delete require.cache[require.resolve('../../src/myft-api')];
 				MyFtApi = require('../../src/myft-api');
 			});
 
-			afterEach(function () {
+			after(() => {
 				process.env.BYPASS_MYFT_MAINTENANCE_MODE = originalBypassMaintenanceMode;
 			});
 

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -9,6 +9,7 @@ describe('myFT node API', () => {
 
 	let MyFtApi = require('../../src/myft-api');
 	let myFtApi = new MyFtApi({ apiRoot: 'https://test-api-route.com/' });
+
 	const userId = '00000000-0000-0000-0000-000000000001';
 	const defaultHeaders = { 'Content-Type': 'application/json' };
 

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -103,14 +103,20 @@ describe('myFT node API', () => {
 			});
 		});
 
-		it('should throw errors when api returns 404', (done) => {
+		it('should throw errors when api returns 404', async () => {
 			const endpoint = `endpoint/${userId}`;
-			fetchMock.mock('https://test-api-route.com/endpoint/00000000-0000-0000-0000-000000000001', 404);
-			myFtApi.fetchJson('GET', endpoint)
-				.catch(err => {
-					expect(err).to.deep.equal(new Error('Request must not contain undefined. Invalid path: ' + endpoint));
-					done();
-				});
+			fetchMock.restore();
+			const readable = new fetchMock.stream.Readable();
+			readable.push('response string');
+			readable.push(null);
+
+			fetchMock.mock('https://test-api-route.com/endpoint/00000000-0000-0000-0000-000000000001', { status: 404, body: readable, sendAsJson: false });
+			try {
+				await myFtApi.fetchJson('GET', endpoint)
+				throw new Error(`Expected error didn't throw!`)
+			} catch (err) {
+				expect(err).to.deep.equal(new Error('No user data exists'));
+			}
 		});
 	});
 

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -16,6 +16,7 @@ describe('myFT node API', () => {
 
 	const userId = '00000000-0000-0000-0000-000000000001';
 	const defaultHeaders = { 'Content-Type': 'application/json' };
+	const endpoint = `user/${userId}`;
 
 	afterEach(function () {
 		fetchMock.reset();
@@ -47,7 +48,6 @@ describe('myFT node API', () => {
 	describe('getAllRelationship', async () => {
 		it('should request the API', async () => {
 			await myFtApi.getAllRelationship('user', userId, 'followed', 'concept');
-
 			expect(fetchMock.called()).to.be.true;
 		});
 
@@ -66,7 +66,7 @@ describe('myFT node API', () => {
 		it('should pass correct opts to the API calls', async () => {
 			const method = 'GET';
 			const timeout = 1406;
-			await myFtApi.fetchJson(method, 'endpoint', null, { timeout });
+			await myFtApi.fetchJson(method, endpoint, null, { timeout });
 
 			expect(fetchMock.lastOptions(apiRootMatcher)).to.deep.equal({
 				method,
@@ -77,20 +77,19 @@ describe('myFT node API', () => {
 		});
 
 		it('should reject when endpoint includes undefined', async () => {
-			const endpoint = `endpoint/undefined/${userId}`;
+			const invalidEndpoint = 'user/undefined';
 			try {
-				await myFtApi.fetchJson('GET', endpoint);
+				await myFtApi.fetchJson('GET', invalidEndpoint);
 				throw new Error('Expected error did not throw!');
 			} catch (err) {
-				expect(err).to.deep.equal(new Error('Request must not contain undefined. Invalid path: ' + endpoint));
+				expect(err).to.deep.equal(new Error('Request must not contain undefined. Invalid path: ' + invalidEndpoint));
 			}
 		});
 
 		it('should pass data as query params when method is GET', async () => {
-			const endpoint = 'endpoint';
 			const paramOne = 'paramOneValue';
 			const paramTwo = 'paramTwoValue';
-			await myFtApi.fetchJson('GET', 'endpoint', { paramOne, paramTwo});
+			await myFtApi.fetchJson('GET', endpoint, { paramOne, paramTwo });
 
 			expect(fetchMock.lastUrl(apiRootMatcher)).to.equal(
 				`${apiRoot}${endpoint}?paramOne=${paramOne}&paramTwo=${paramTwo}`
@@ -98,17 +97,15 @@ describe('myFT node API', () => {
 		});
 
 		it('should not pass data as query params when method is not GET', async () => {
-			const endpoint = 'endpoint';
 			const paramOne = 'paramOneValue';
 			const paramTwo = 'paramTwoValue';
-			await myFtApi.fetchJson('PUT', 'endpoint', { paramOne, paramTwo});
+			await myFtApi.fetchJson('PUT', endpoint, { paramOne, paramTwo });
 
 			expect(fetchMock.lastUrl(apiRootMatcher)).to.equal(`${apiRoot}${endpoint}`);
 		});
 
 		it('should throw errors when api returns 404', async () => {
 			const apiRoot404 = 'https://test-api-404.com/';
-			const endpoint = `user/${userId}`;
 			const readable = new fetchMock.stream.Readable();
 			readable.push('response string');
 			readable.push(null);
@@ -152,7 +149,7 @@ describe('myFT node API', () => {
 		describe('fetchJson', () => {
 			it('should pass function opts header to the API calls', async () => {
 				myFtApi = new MyFtApi({ apiRoot, headers: optsHeaders });
-				await myFtApi.fetchJson('GET', 'endpoint', null, { headers: functionOptsHeaders });
+				await myFtApi.fetchJson('GET', endpoint, null, { headers: functionOptsHeaders });
 
 				expect(fetchMock.lastOptions(apiRootMatcher).headers).to.deep.equal({
 					...defaultHeaders,
@@ -181,7 +178,7 @@ describe('myFT node API', () => {
 					myFtApi = new MyFtApi({ apiRoot, headers: optsHeaders });
 					const data = { 'a': 'b' };
 					const contentLength = Buffer.byteLength(JSON.stringify(data));
-					await myFtApi.fetchJson('PUT', 'endpoint', data);
+					await myFtApi.fetchJson('PUT', endpoint, data);
 
 					expect(fetchMock.lastOptions(apiRootMatcher).headers).to.deep.equal({
 						...defaultHeaders,
@@ -192,7 +189,7 @@ describe('myFT node API', () => {
 
 				it('should set Content-Length header with 0 when method is GET', async () => {
 					myFtApi = new MyFtApi({ apiRoot, headers: optsHeaders });
-					await myFtApi.fetchJson('GET', 'endpoint');
+					await myFtApi.fetchJson('GET', endpoint);
 
 					expect(fetchMock.lastOptions(apiRootMatcher).headers).to.deep.equal({
 						...defaultHeaders,
@@ -275,10 +272,11 @@ describe('myFT node API', () => {
 
 			it('should pass a flag to bypass maintenance mode', async () => {
 				myFtApi = new MyFtApi({ apiRoot });
-				await myFtApi.getAllRelationship('user', userId, 'followed', 'concept');
+				await myFtApi.getAllRelationship('user', userId, 'followed', 'concept', {}, { headers: functionOptsHeaders });
 
 				expect(fetchMock.lastOptions(apiRootMatcher).headers).to.deep.equal({
 					...defaultHeaders,
+					...functionOptsHeaders,
 					...bypassMyftMaintenanceHeader
 				});
 			});

--- a/test/node/myft-api.spec.js
+++ b/test/node/myft-api.spec.js
@@ -54,6 +54,9 @@ describe('myFT node API', () => {
 
 		const defaultHeaders = { 'Content-Type': 'application/json' };
 		const optsHeaders = { 'x-opts-header': 'x-opts-header-value' };
+		const functionOptsHeaders = {
+			'x-function-opts-header': 'x-function-opts-header-value'
+		};
 
 		it('should have correct default headers', () => {
 			myFtApi = new MyFtApi({ apiRoot: 'https://test-api-route.com/' });
@@ -74,6 +77,73 @@ describe('myFT node API', () => {
 		it('should not pass a flag to bypass maintenance mode', () => {
 			return myFtApi.getAllRelationship('user', userId, 'followed', 'concept').then(() => {
 				expect(fetchMock.lastOptions('*').headers['ft-bypass-myft-maintenance-mode']).to.not.be.true;
+			});
+		});
+
+		describe('fetchJson', function () {
+			it('should pass function opts header to the API calls', () => {
+				myFtApi = new MyFtApi({
+					apiRoot: 'https://test-api-route.com/',
+					headers: optsHeaders
+				});
+				return myFtApi.fetchJson('GET', 'endpont', null, { headers: functionOptsHeaders }).then(() => {
+					expect(fetchMock.lastOptions('*').headers).to.deep.equal({
+						...defaultHeaders,
+						...optsHeaders,
+						...functionOptsHeaders
+					});
+				});
+			});
+		});
+
+		describe('getConceptsFromReadingHistory', function () {
+			it('should pass function opts header to the API calls', () => {
+				myFtApi = new MyFtApi({
+					apiRoot: 'https://test-api-route.com/',
+					headers: optsHeaders
+				});
+				return myFtApi.getConceptsFromReadingHistory(userId, 10, {}, functionOptsHeaders).then(() => {
+					expect(fetchMock.lastOptions('*').headers).to.deep.equal({
+						...defaultHeaders,
+						...optsHeaders,
+						...functionOptsHeaders,
+						'ft-user-uuid': userId
+					});
+				});
+			});
+		});
+
+		describe('getArticlesFromReadingHistory', function () {
+			it('should pass function opts header to the API calls', () => {
+				myFtApi = new MyFtApi({
+					apiRoot: 'https://test-api-route.com/',
+					headers: optsHeaders
+				});
+				return myFtApi.getArticlesFromReadingHistory(userId, -7, {}, functionOptsHeaders).then(() => {
+					expect(fetchMock.lastOptions('*').headers).to.deep.equal({
+						...defaultHeaders,
+						...optsHeaders,
+						...functionOptsHeaders,
+						'ft-user-uuid': userId
+					});
+				});
+			});
+		});
+
+		describe('getUserLastSeenTimestamp', function () {
+			it('should pass function opts header to the API calls', () => {
+				myFtApi = new MyFtApi({
+					apiRoot: 'https://test-api-route.com/',
+					headers: optsHeaders
+				});
+				return myFtApi.getUserLastSeenTimestamp(userId, { headers: functionOptsHeaders }).then(() => {
+					expect(fetchMock.lastOptions('*').headers).to.deep.equal({
+						...defaultHeaders,
+						...optsHeaders,
+						...functionOptsHeaders,
+						'ft-user-uuid': userId
+					});
+				});
 			});
 		});
 


### PR DESCRIPTION
This PR is to allow each **SERVER** side functions to pass header options correctlly.

### The headers are set in 3 places
- When next-myft-client is initialized
```js
const MyFtApi = require('next-myft-client');
const myFtApi = new MyFtApi({
    apiRoot: 'https://api.com',
    headers: { 'x-my-header': 'yes' }
});
```
- When headers are added to next-myft-client instance directly
```js
const MyFtApi = require('next-myft-client');
const myFtApi = new MyFtApi({ apiRoot: 'https://api.com' });
myFTApi.headers['x-my-header'] = 'yes'
```
- When opts includes headers object are passed to the function
```js
const MyFtApi = require('next-myft-client');
const myFtApi = new MyFtApi({ apiRoot: 'https://api.com' });
myFTApi.getAllRelationship('user', userId, 'followed', 'concept', {}, {
   headers: { 'x-my-header': 'yes' }
})
```
### 4 types of headers
- **Default headers:** They are set as default (e.g. `'Content-Type': 'application/json'`)
- **Opts headers:** They can be passed when next-myft-client is initialized
- **Env headers:** They can be set via Env var (e.g.`ft-bypass-myft-maintenance-mode` )
- **Function Opt headers:** They can be passed when function is called

-----

The headers setting is not simple, however, there were not enough tests around headers. Therefore, I added tests first and I found **3 bugs** around server side header code.

The first bug, some functions couldn't pass headers properly.
❌ [The CircleCI failure](https://app.circleci.com/pipelines/github/Financial-Times/next-myft-client/1862/workflows/77dd090a-c16d-4c72-86d2-21748d2e34b2/jobs/7171/parallel-runs/0/steps/0-102)
🛠 [The fix commit bff20e4](https://github.com/Financial-Times/next-myft-client/pull/206/commits/bff20e464c626f5a74c1a5e4199ade4132a9512f)

The second bug, `Content-Length` header is not set correctly. It's set next request not the target request.
❌ [The CircleCI failure](https://app.circleci.com/pipelines/github/Financial-Times/next-myft-client/1864/workflows/5f7a2696-4f44-4906-a5f2-626a29df061c/jobs/7186/parallel-runs/0/steps/0-102)
🛠 [The fix commit bc1432e](https://github.com/Financial-Times/next-myft-client/pull/206/commits/bc1432e1f093da9919248a2c8582b8483881ed97)

The third bug, it sets the maintenance header even when `BYPASS_MYFT_MAINTENANCE_MODE` is set to `'false'`
🛠 [The fix commit 84ab6a3](https://github.com/Financial-Times/next-myft-client/pull/206/commits/84ab6a3aa19a68cef6100101334517276123242a)
