### PR TITLE
CON-3224: Pass SYSTEM_CODE env as x-origin-system-id header

### DIFF
--- a/src/myft-api.js
+++ b/src/myft-api.js
@@ -18,6 +18,10 @@ if (process.env.BYPASS_MYFT_MAINTENANCE_MODE === 'true') {
 	envHeaders['ft-bypass-myft-maintenance-mode'] = 'true';
 }
 
+if(process.env.SYSTEM_CODE) {
+	envHeaders['x-origin-system-id'] = process.env.SYSTEM_CODE;
+}
+
 class MyFtApi {
 	constructor (opts) {
 		if (!opts.apiRoot) {


### PR DESCRIPTION
Follow up PR for https://github.com/Financial-Times/next-myft-client/pull/206

If the consumer app has `SYSTEM_CODE` env set up, it passes to the next-myft-api requests as `x-origin-system-id` header.